### PR TITLE
Fixing PHP notice that got triggered when $clause['alias'] doesn't exist.

### DIFF
--- a/src/PHPSQLParser/processors/HavingProcessor.php
+++ b/src/PHPSQLParser/processors/HavingProcessor.php
@@ -61,7 +61,7 @@ class HavingProcessor extends ExpressionListProcessor {
         foreach ($parsed as $k => $v) {
             if ($v['expr_type'] === ExpressionType::COLREF) {
                 foreach ($select as $clause) {
-                    if (!$clause['alias']) {
+                    if (empty($clause['alias'])) {
                         continue;
                     }
 


### PR DESCRIPTION
This expression
```
HAVING
	change_id > :change_id
```
produces several tokens and couple of them are empty, so the `$clause` doesn't contain anything but
```
array (size=1)
  'delim' => boolean false
```
Probably that should be fixed in tokeniser.