### PR TITLE
Remove repositories section from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,28 +45,5 @@
     {
     	"squizlabs/php_codesniffer": ">=1.5.1",
         "phpunit/phpunit": ">=4.0.14"
-    },
-    "repositories": [
-        {
-            "type": "package",
-            "package": 
-            {
-                "name": "greenlion/php-sql-parser",
-                "version": "4.0.0",
-                "dist": 
-                {
-                    "type": "zip",
-                    "url": "https://github.com/greenlion/PHP-SQL-Parser/releases/download/v4.0.0/php-sql-parser-4.0.0.zip"
-                }
-            }
-        },
-        {
-            "type": "git",
-            "url": "https://github.com/greenlion/PHP-SQL-Parser.git"
-        },
-        {
-            "type": "svn",
-            "url": "http://php-sql-parser.googlecode.com/svn/trunk/"
-        }
-    ]
+    }
 }


### PR DESCRIPTION
After doing a little more research/work on the project and familiarizing myself with the codebase, I can see that the repositories section isn't needed. 

It just complicates installation by making composer needlessly scan these repo's despite Github being the repo it should be pulling from.
