### PR TITLE
Fixes Abstract Test Autoload Issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		}
 	},
 	"autoload-dev" : {
-		"psr-0" : {
+		"psr-4" : {
 			"PHPSQLParser\\Test\\" : "tests/cases/"
 		}
 	},


### PR DESCRIPTION
PSR-0 expects the `PHPSQLParser\Test` directories to exist, whereas PSR-4 excludes them when defined as this. This would be what you want and appears to correct the issue.
