### PR TITLE
Fixing mixed quotes detection 

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
   backupStaticAttributes="false"
-  syntaxCheck="false" verbose="true">
+  syntaxCheck="false" verbose="true"
+  bootstrap="tests/bootstrap.php">
   <testsuites>
     <testsuite name="Tests">
        <directory suffix="Test.php">tests</directory>

--- a/src/PHPSQLParser/processors/AbstractProcessor.php
+++ b/src/PHPSQLParser/processors/AbstractProcessor.php
@@ -166,6 +166,8 @@ abstract class AbstractProcessor {
         $parenthesis = $parenthesisRemoved;
         $i = 0;
         $string = 0;
+        // Whether a string was opened or not, and with which character it was open (' or ")
+        $stringOpened = '';
         while ($i < strlen($trim)) {
 
             if ($trim[$i] === "\\") {
@@ -173,15 +175,27 @@ abstract class AbstractProcessor {
                 continue;
             }
 
-            if ($trim[$i] === "'" || $trim[$i] === '"') {
-                $string++;
+            if ($trim[$i] === "'") {
+                if ($stringOpened === '') {
+                    $stringOpened = "'";
+                } elseif ($stringOpened === "'") {
+                    $stringOpened = '';
+                }
             }
 
-            if (($string % 2 === 0) && ($trim[$i] === '(')) {
+            if ($trim[$i] === '"') {
+                if ($stringOpened === '') {
+                    $stringOpened = '"';
+                } elseif ($stringOpened === '"') {
+                    $stringOpened = '';
+                }
+            }
+
+            if (($stringOpened === '') && ($trim[$i] === '(')) {
                 $parenthesis++;
             }
 
-            if (($string % 2 === 0) && ($trim[$i] === ')')) {
+            if (($stringOpened === '') && ($trim[$i] === ')')) {
                 if ($parenthesis == $parenthesisRemoved) {
                     $trim[$i] = ' ';
                     $parenthesisRemoved--;

--- a/tests/cases/parser/mixedQuotesTest.php
+++ b/tests/cases/parser/mixedQuotesTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * mixedQuotesTest.php
+ *
+ * Test case for PHPSQLParser.
+ *
+ * PHP version 5
+ *
+ * LICENSE:
+ * Copyright (c) 2010-2014 Justin Swanhart and André Rothe
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author    André Rothe <andre.rothe@phosco.info>
+ * @copyright 2010-2014 Justin Swanhart and André Rothe
+ * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
+ * @version   SVN: $Id$
+ *
+ */
+namespace PHPSQLParser\Test\Parser;
+use PHPSQLParser\PHPSQLParser;
+use PHPSQLParser\PHPSQLCreator;
+
+class mixedQuotesTest extends \PHPUnit_Framework_TestCase {
+
+    public function testMixedQuotes() {
+        $parser = new PHPSQLParser();
+
+        $sql = 'SELECT ISNULL(\'"\') AS foo FROM bar;';
+        $parser->parse($sql);
+
+        $this->assertEquals('\'"\'', $parser->parsed['SELECT'][0]['sub_tree'][0]['base_expr'], "Mixed quotes test failed");
+    }
+}


### PR DESCRIPTION
String detections is somewhat broken if you put double quotes inside a string declared with single quotes.

For instance, this query:

```sql
SELECT ISNULL('"') AS foo FROM bar;
```

is not correctly parsed. The parser will think the double quote is closing the single quote and mess with the rest of the query.

This pull request fixes this problem. It comes with a unit test demonstrating the change.

Also, there has been quite some changes since the last stable release. Would you consider tagging a new release?