### PR TITLE
fix for MULTIPLE_PARAM_PARENTHESIS sub tree expressions

### DIFF
--- a/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php
+++ b/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php
@@ -394,8 +394,13 @@ class ColumnDefinitionProcessor extends AbstractProcessor {
                     $parsed = $this->processExpressionList($trim);
 
                     $last = array_pop($expr);
-                    $last['sub_tree'] = array('expr_type' => ExpressionType::BRACKET_EXPRESSION, 'base_expr' => $trim,
-                                              'sub_tree' => $parsed);
+                    $last['sub_tree'] = array(
+                                            array(
+                                                'expr_type' => ExpressionType::BRACKET_EXPRESSION,
+                                                'base_expr' => $trim,
+                                                'sub_tree' => $parsed
+                                            )
+                                        );
                     $expr[] = $last;
                     $currCategory = $prevCategory;
                     break;


### PR DESCRIPTION
With MULTIPLE_PARAM_PARENTHESIS, there was an expression array included under the 'sub_tree' key of the parent expression, which is inconsistent comparing to sub_tree generation in other places. I suppose this is a bug, so I fixed it.