### PR TITLE
Revert "fix for MULTIPLE_PARAM_PARENTHESIS sub tree expressions"

### DIFF
--- a/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php
+++ b/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php
@@ -394,13 +394,8 @@ class ColumnDefinitionProcessor extends AbstractProcessor {
                     $parsed = $this->processExpressionList($trim);
 
                     $last = array_pop($expr);
-                    $last['sub_tree'] = array(
-                                            array(
-                                                'expr_type' => ExpressionType::BRACKET_EXPRESSION,
-                                                'base_expr' => $trim,
-                                                'sub_tree' => $parsed
-                                            )
-                                        );
+                    $last['sub_tree'] = array('expr_type' => ExpressionType::BRACKET_EXPRESSION, 'base_expr' => $trim,
+                                              'sub_tree' => $parsed);
                     $expr[] = $last;
                     $currCategory = $prevCategory;
                     break;


### PR DESCRIPTION
Reverts greenlion/PHP-SQL-Parser#205

This makes the sub_tree inconsistent for SINGLE_PARAM_PARENTHESIS and TWO_PARAM_PARENTHESIS and could cause problems for existing tools using
the parser and handling MULTIPLE_PARAM_PARENTHESIS.