### PR TITLE
Optional $options parameter for the SQLParser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.lock
 clover.xml
 composer.phar
+.idea

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="" />
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,3 +1,0 @@
-<component name="CopyrightManager">
-  <settings default="" />
-</component>

--- a/src/PHPSQLParser/Options.php
+++ b/src/PHPSQLParser/Options.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @author     mfris
+ *
+ */
+
+namespace PHPSQLParser;
+
+/**
+ *
+ * @author  mfris
+ * @package PHPSQLParser
+ */
+final class Options
+{
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @const string
+     */
+    const CONSISTENT_SUB_TREES = 'consistent_sub_trees';
+
+    /**
+     * Options constructor.
+     *
+     * @param array $options
+     */
+    public function __construct(array $options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getConsistentSubtrees()
+    {
+        return (isset($this->options[self::CONSISTENT_SUB_TREES]) && $this->options[self::CONSISTENT_SUB_TREES]);
+    }
+}

--- a/src/PHPSQLParser/PHPSQLParser.php
+++ b/src/PHPSQLParser/PHPSQLParser.php
@@ -32,7 +32,7 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * @author    André Rothe <andre.rothe@phosco.info>
  * @copyright 2010-2014 Justin Swanhart and André Rothe
  * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
@@ -56,34 +56,42 @@ class PHPSQLParser {
     public $parsed;
 
     /**
-     * Constructor. It simply calls the parse() function. 
-     * Use the public variable $parsed to get the output.
-     * 
-     * @param String  $sql           The SQL statement.
-     * @param boolean $calcPositions True, if the output should contain [position], false otherwise.
+     * @var Options
      */
-    public function __construct($sql = false, $calcPositions = false) {
+    private $options;
+
+    /**
+     * Constructor. It simply calls the parse() function.
+     * Use the public variable $parsed to get the output.
+     *
+     * @param String|bool  $sql           The SQL statement.
+     * @param bool $calcPositions True, if the output should contain [position], false otherwise.
+     * @param array $options
+     */
+    public function __construct($sql = false, $calcPositions = false, array $options = []) {
+        $this->options = new Options($options);
+
         if ($sql) {
             $this->parse($sql, $calcPositions);
         }
     }
 
     /**
-     * It parses the given SQL statement and generates a detailled 
-     * output array for every part of the statement. The method can 
-     * also generate [position] fields within the output, which hold 
-     * the character position for every statement part. The calculation 
+     * It parses the given SQL statement and generates a detailled
+     * output array for every part of the statement. The method can
+     * also generate [position] fields within the output, which hold
+     * the character position for every statement part. The calculation
      * of the positions needs some time, if you don't need positions in
      * your application, set the parameter to false.
-     * 
+     *
      * @param String  $sql           The SQL statement.
      * @param boolean $calcPositions True, if the output should contain [position], false otherwise.
-     * 
+     *
      * @return array An associative array with all meta information about the SQL statement.
      */
     public function parse($sql, $calcPositions = false) {
 
-        $processor = new DefaultProcessor();
+        $processor = new DefaultProcessor($this->options);
         $queries = $processor->process($sql);
 
         // calc the positions of some important tokens
@@ -99,9 +107,9 @@ class PHPSQLParser {
 
     /**
      * Add a custom function to the parser.  no return value
-     * 
+     *
      * @param String $token The name of the function to add
-     * 
+     *
      * @return null
      */
     public function addCustomFunction($token) {
@@ -110,9 +118,9 @@ class PHPSQLParser {
 
     /**
      * Remove a custom function from the parser.  no return value
-     * 
+     *
      * @param String $token The name of the function to remove
-     * 
+     *
      * @return null
      */
     public function removeCustomFunction($token) {
@@ -121,8 +129,8 @@ class PHPSQLParser {
 
     /**
      * Returns the list of custom functions
-     * 
-     * @return array Returns an array of all custom functions 
+     *
+     * @return array Returns an array of all custom functions
      */
     public function getCustomFunctions() {
         return PHPSQLParserConstants::getInstance()->getCustomFunctions();

--- a/src/PHPSQLParser/processors/AbstractProcessor.php
+++ b/src/PHPSQLParser/processors/AbstractProcessor.php
@@ -42,16 +42,32 @@
 namespace PHPSQLParser\processors;
 
 use PHPSQLParser\lexer\PHPSQLLexer;
+use PHPSQLParser\Options;
 use PHPSQLParser\utils\ExpressionType;
 
 /**
  * This class contains some general functions for a processor.
- * 
+ *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- * 
+ *
  */
 abstract class AbstractProcessor {
+
+    /**
+     * @var Options
+     */
+    protected $options;
+
+    /**
+     * AbstractProcessor constructor.
+     *
+     * @param Options $options
+     */
+    public function __construct(Options $options)
+    {
+        $this->options = $options;
+    }
 
     /**
      * This function implements the main functionality of a processor class.
@@ -78,9 +94,9 @@ abstract class AbstractProcessor {
      *   `a.b`
      *   a.`b`
      *   `a`.b
-     * It is also possible to have escaped quoting characters 
+     * It is also possible to have escaped quoting characters
      * within an expression part:
-     *   `a``b` => a`b 
+     *   `a``b` => a`b
      * And you can use whitespace between the parts:
      *   a  .  `b` => [a,b]
      */
@@ -278,11 +294,11 @@ abstract class AbstractProcessor {
     protected function isSubQuery($out) {
         return (isset($out['expr_type']) && $out['expr_type'] === ExpressionType::SUBQUERY);
     }
-    
+
     protected function isComment($out) {
         return (isset($out['expr_type']) && $out['expr_type'] === ExpressionType::COMMENT);
     }
-    
+
     public function processComment($expression) {
         $result = array();
         $result['expr_type'] = ExpressionType::COMMENT;

--- a/src/PHPSQLParser/processors/BracketProcessor.php
+++ b/src/PHPSQLParser/processors/BracketProcessor.php
@@ -3,7 +3,7 @@
  * BracketProcessor.php
  *
  * This file implements the processor for the parentheses around the statements.
- * 
+ *
  * PHP version 5
  *
  * LICENSE:
@@ -44,15 +44,15 @@ use PHPSQLParser\utils\ExpressionType;
 
 /**
  * This class processes the parentheses around the statement.
- * 
+ *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- * 
+ *
  */
 class BracketProcessor extends AbstractProcessor {
 
     protected function processTopLevel($sql) {
-        $processor = new DefaultProcessor();
+        $processor = new DefaultProcessor($this->options);
         return $processor->process($sql);
     }
 

--- a/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php
+++ b/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php
@@ -43,7 +43,7 @@ use PHPSQLParser\utils\ExpressionType;
 class ColumnDefinitionProcessor extends AbstractProcessor {
 
     protected function processExpressionList($parsed) {
-        $processor = new ExpressionListProcessor();
+        $processor = new ExpressionListProcessor($this->options);
         $expr = $this->removeParenthesisFromStart($parsed);
         $expr = $this->splitSQLIntoTokens($expr);
         $expr = $this->removeComma($expr);
@@ -51,7 +51,7 @@ class ColumnDefinitionProcessor extends AbstractProcessor {
     }
 
     protected function processReferenceDefinition($parsed) {
-        $processor = new ReferenceDefinitionProcessor();
+        $processor = new ReferenceDefinitionProcessor($this->options);
         return $processor->process($parsed);
     }
 
@@ -394,8 +394,14 @@ class ColumnDefinitionProcessor extends AbstractProcessor {
                     $parsed = $this->processExpressionList($trim);
 
                     $last = array_pop($expr);
-                    $last['sub_tree'] = array('expr_type' => ExpressionType::BRACKET_EXPRESSION, 'base_expr' => $trim,
-                                              'sub_tree' => $parsed);
+                    $subTree = array('expr_type' => ExpressionType::BRACKET_EXPRESSION, 'base_expr' => $trim,
+                                     'sub_tree' => $parsed);
+
+                    if ($this->options->getConsistentSubtrees()) {
+                        $subTree = array($subTree);
+                    }
+
+                    $last['sub_tree'] = $subTree;
                     $expr[] = $last;
                     $currCategory = $prevCategory;
                     break;

--- a/src/PHPSQLParser/processors/CreateDefinitionProcessor.php
+++ b/src/PHPSQLParser/processors/CreateDefinitionProcessor.php
@@ -47,27 +47,27 @@ use PHPSQLParser\utils\ExpressionType;
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class CreateDefinitionProcessor extends AbstractProcessor {
 
     protected function processExpressionList($parsed) {
-        $processor = new ExpressionListProcessor();
+        $processor = new ExpressionListProcessor($this->options);
         return $processor->process($parsed);
     }
 
     protected function processIndexColumnList($parsed) {
-        $processor = new IndexColumnListProcessor();
+        $processor = new IndexColumnListProcessor($this->options);
         return $processor->process($parsed);
     }
 
     protected function processColumnDefinition($parsed) {
-        $processor = new ColumnDefinitionProcessor();
+        $processor = new ColumnDefinitionProcessor($this->options);
         return $processor->process($parsed);
     }
 
     protected function processReferenceDefinition($parsed) {
-        $processor = new ReferenceDefinitionProcessor();
+        $processor = new ReferenceDefinitionProcessor($this->options);
         return $processor->process($parsed);
     }
 

--- a/src/PHPSQLParser/processors/DefaultProcessor.php
+++ b/src/PHPSQLParser/processors/DefaultProcessor.php
@@ -57,12 +57,12 @@ class DefaultProcessor extends AbstractProcessor {
     protected function processUnion($tokens) {
         // this is the highest level lexical analysis. This is the part of the
         // code which finds UNION and UNION ALL query parts
-        $processor = new UnionProcessor();
+        $processor = new UnionProcessor($this->options);
         return $processor->process($tokens);
     }
 
     protected function processSQL($tokens) {
-        $processor = new SQLProcessor();
+        $processor = new SQLProcessor($this->options);
         return $processor->process($tokens);
     }
 

--- a/src/PHPSQLParser/processors/ExpressionListProcessor.php
+++ b/src/PHPSQLParser/processors/ExpressionListProcessor.php
@@ -59,8 +59,8 @@ class ExpressionListProcessor extends AbstractProcessor {
         $prev = new ExpressionToken();
 
         foreach ($tokens as $k => $v) {
-            
-            
+
+
             if ($this->isCommentToken($v)) {
                 $resultList[] = parent::processComment($v);
                 continue;
@@ -81,7 +81,7 @@ class ExpressionListProcessor extends AbstractProcessor {
             /* is it a subquery? */
             if ($curr->isSubQueryToken()) {
 
-                $processor = new DefaultProcessor();
+                $processor = new DefaultProcessor($this->options);
                 $curr->setSubTree($processor->process($this->removeParenthesisFromStart($curr->getTrim())));
                 $curr->setTokenType(ExpressionType::SUBQUERY);
 
@@ -208,7 +208,7 @@ class ExpressionListProcessor extends AbstractProcessor {
                         } else {
                             $prev->setTokenType(ExpressionType::SIMPLE_FUNCTION);
                         }
-                        $prev->setNoQuotes(null);
+                        $prev->setNoQuotes(null, null, $this->options);
                     }
 
                     array_pop($resultList);
@@ -275,7 +275,7 @@ class ExpressionListProcessor extends AbstractProcessor {
 
                 $curr->setTokenType($this->getVariableType($curr->getUpper()));
                 $curr->setSubTree(false);
-                $curr->setNoQuotes(trim(trim($curr->getToken()), '@'), "`'\"");
+                $curr->setNoQuotes(trim(trim($curr->getToken()), '@'), "`'\"", $this->options);
 
             } else {
                 /* it is either an operator, a colref or a constant */
@@ -376,7 +376,7 @@ class ExpressionListProcessor extends AbstractProcessor {
                     case '`':
                     // it is an escaped colum name
                         $curr->setTokenType(ExpressionType::COLREF);
-                        $curr->setNoQuotes($curr->getToken());
+                        $curr->setNoQuotes($curr->getToken(), null, $this->options);
                         break;
 
                     default:
@@ -392,7 +392,7 @@ class ExpressionListProcessor extends AbstractProcessor {
                             }
                         } else {
                             $curr->setTokenType(ExpressionType::COLREF);
-                            $curr->setNoQuotes($curr->getToken());
+                            $curr->setNoQuotes($curr->getToken(), null, $this->options);
                         }
                         break;
                     }
@@ -405,11 +405,11 @@ class ExpressionListProcessor extends AbstractProcessor {
 
                 if (PHPSQLParserConstants::getInstance()->isCustomFunction($curr->getUpper())) {
                     $curr->setTokenType(ExpressionType::CUSTOM_FUNCTION);
-                    $curr->setNoQuotes(null);
+                    $curr->setNoQuotes(null, null, $this->options);
 
                 } elseif (PHPSQLParserConstants::getInstance()->isAggregateFunction($curr->getUpper())) {
                     $curr->setTokenType(ExpressionType::AGGREGATE_FUNCTION);
-                    $curr->setNoQuotes(null);
+                    $curr->setNoQuotes(null, null, $this->options);
 
                 } elseif ($curr->getUpper() === 'NULL') {
                     // it is a reserved word, but we would like to set it as constant
@@ -424,11 +424,11 @@ class ExpressionListProcessor extends AbstractProcessor {
 
                     } elseif (PHPSQLParserConstants::getInstance()->isFunction($curr->getUpper())) {
                         $curr->setTokenType(ExpressionType::SIMPLE_FUNCTION);
-                        $curr->setNoQuotes(null);
+                        $curr->setNoQuotes(null, null, $this->options);
 
                     } else {
                         $curr->setTokenType(ExpressionType::RESERVED);
-                        $curr->setNoQuotes(null);
+                        $curr->setNoQuotes(null, null, $this->options);
                     }
                 }
             }
@@ -436,17 +436,17 @@ class ExpressionListProcessor extends AbstractProcessor {
             // issue 94, INTERVAL 1 MONTH
             if ($curr->isConstant() && PHPSQLParserConstants::getInstance()->isParameterizedFunction($prev->getUpper())) {
                 $prev->setTokenType(ExpressionType::RESERVED);
-                $prev->setNoQuotes(null);
+                $prev->setNoQuotes(null, null, $this->options);
             }
 
             if ($prev->isConstant() && PHPSQLParserConstants::getInstance()->isParameterizedFunction($curr->getUpper())) {
                 $curr->setTokenType(ExpressionType::RESERVED);
-                $curr->setNoQuotes(null);
+                $curr->setNoQuotes(null, null, $this->options);
             }
 
             if ($curr->isUnspecified()) {
                 $curr->setTokenType(ExpressionType::EXPRESSION);
-                $curr->setNoQuotes(null);
+                $curr->setNoQuotes(null, null, $this->options);
                 $curr->setSubTree($this->process($this->splitSQLIntoTokens($curr->getTrim())));
             }
 

--- a/src/PHPSQLParser/processors/FromProcessor.php
+++ b/src/PHPSQLParser/processors/FromProcessor.php
@@ -55,20 +55,20 @@ use PHPSQLParser\utils\ExpressionType;
 class FromProcessor extends AbstractProcessor {
 
     protected function processExpressionList($unparsed) {
-        $processor = new ExpressionListProcessor();
+        $processor = new ExpressionListProcessor($this->options);
         return $processor->process($unparsed);
     }
-    
+
     protected function processColumnList($unparsed) {
-        $processor = new ColumnListProcessor();
+        $processor = new ColumnListProcessor($this->options);
         return $processor->process($unparsed);
     }
-    
+
     protected function processSQLDefault($unparsed) {
-        $processor = new DefaultProcessor();
+        $processor = new DefaultProcessor($this->options);
         return $processor->process($unparsed);
     }
-    
+
     protected function initParseInfo($parseInfo = false) {
         // first init
         if ($parseInfo === false) {
@@ -168,12 +168,12 @@ class FromProcessor extends AbstractProcessor {
                     continue;
                 }
             }
-            
+
             if ($this->isCommentToken($token)) {
                 $expr[] = parent::processComment($token);
                 continue;
             }
-            
+
             switch ($upper) {
             case 'CROSS':
             case ',':
@@ -191,12 +191,12 @@ class FromProcessor extends AbstractProcessor {
 
             case 'LEFT':
             case 'RIGHT':
-            case 'NATURAL':            	
+            case 'NATURAL':
                 $token_category = $upper;
                 $prevToken = $token;
                 $i++;
                 continue 2;
-                
+
             default:
                 if ($token_category === 'LEFT' || $token_category === 'RIGHT') {
                     if ($upper === '') {

--- a/src/PHPSQLParser/processors/IndexProcessor.php
+++ b/src/PHPSQLParser/processors/IndexProcessor.php
@@ -47,7 +47,7 @@ use PHPSQLParser\utils\ExpressionType;
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class IndexProcessor extends AbstractProcessor {
 
@@ -64,7 +64,7 @@ class IndexProcessor extends AbstractProcessor {
     }
 
     protected function processIndexColumnList($parsed) {
-        $processor = new IndexColumnListProcessor();
+        $processor = new IndexColumnListProcessor($this->options);
         return $processor->process($parsed);
     }
 

--- a/src/PHPSQLParser/processors/InsertProcessor.php
+++ b/src/PHPSQLParser/processors/InsertProcessor.php
@@ -2,7 +2,7 @@
 /**
  * InsertProcessor.php
  *
- * This file implements the processor for the INSERT statements. 
+ * This file implements the processor for the INSERT statements.
  *
  * PHP version 5
  *
@@ -47,7 +47,7 @@ use PHPSQLParser\utils\ExpressionType;
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class InsertProcessor extends AbstractProcessor {
 
@@ -86,7 +86,7 @@ class InsertProcessor extends AbstractProcessor {
 
             case 'INSERT':
                 continue;
-                
+
             default:
                 if ($table === '') {
                     $table = $trim;
@@ -112,12 +112,12 @@ class InsertProcessor extends AbstractProcessor {
         }
         $cols = $this->removeParenthesisFromStart($cols);
         if (stripos($cols, 'SELECT') === 0) {
-            $processor = new DefaultProcessor();
+            $processor = new DefaultProcessor($this->options);
             $parsed['sub_tree'] = array(
                     array('expr_type' => ExpressionType::QUERY, 'base_expr' => $cols,
                             'sub_tree' => $processor->process($cols)));
         } else {
-            $processor = new ColumnListProcessor();
+            $processor = new ColumnListProcessor($this->options);
             $parsed['sub_tree'] = $processor->process($cols);
             $parsed['expr_type'] = ExpressionType::COLUMN_LIST;
         }
@@ -128,7 +128,7 @@ class InsertProcessor extends AbstractProcessor {
         $table = '';
         $cols = false;
         $comments = array();
-        
+
         foreach ($tokenList as $key => &$token) {
             if ($key == 'VALUES') {
                 continue;
@@ -140,7 +140,7 @@ class InsertProcessor extends AbstractProcessor {
                 }
             }
         }
-        
+
         $parsed = $this->processOptions($tokenList);
         unset($tokenList['OPTIONS']);
 
@@ -159,9 +159,9 @@ class InsertProcessor extends AbstractProcessor {
         if ($cols !== false) {
             $parsed[] = $cols;
         }
-        
+
         $parsed = array_merge($parsed, $comments);
-        
+
         $tokenList[$token_category] = $parsed;
         return $tokenList;
     }

--- a/src/PHPSQLParser/processors/OrderByProcessor.php
+++ b/src/PHPSQLParser/processors/OrderByProcessor.php
@@ -47,15 +47,15 @@ use PHPSQLParser\utils\ExpressionType;
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class OrderByProcessor extends AbstractProcessor {
 
     protected function processSelectExpression($unparsed) {
-        $processor = new SelectExpressionProcessor();
+        $processor = new SelectExpressionProcessor($this->options);
         return $processor->process($unparsed);
-    } 
-    
+    }
+
     protected function initParseInfo() {
         return array('base_expr' => "", 'dir' => "ASC", 'expr_type' => ExpressionType::EXPRESSION);
     }
@@ -130,7 +130,7 @@ class OrderByProcessor extends AbstractProcessor {
                     $out[] = parent::processComment($token);
                     break;
                 }
-                
+
                 $parseInfo['base_expr'] .= $token;
             }
         }

--- a/src/PHPSQLParser/processors/PartitionDefinitionProcessor.php
+++ b/src/PHPSQLParser/processors/PartitionDefinitionProcessor.php
@@ -2,7 +2,7 @@
 /**
  * PartitionDefinitionProcessor.php
  *
- * This file implements the processor for the PARTITION statements 
+ * This file implements the processor for the PARTITION statements
  * within CREATE TABLE.
  *
  * PHP version 5
@@ -48,19 +48,19 @@ use PHPSQLParser\utils\ExpressionType;
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class PartitionDefinitionProcessor extends AbstractProcessor {
 
     protected function processExpressionList($unparsed) {
-        $processor = new ExpressionListProcessor();
+        $processor = new ExpressionListProcessor($this->options);
         $expr = $this->removeParenthesisFromStart($unparsed);
         $expr = $this->splitSQLIntoTokens($expr);
         return $processor->process($expr);
     }
 
     protected function processSubpartitionDefinition($unparsed) {
-        $processor = new SubpartitionDefinitionProcessor();
+        $processor = new SubpartitionDefinitionProcessor($this->options);
         $expr = $this->removeParenthesisFromStart($unparsed);
         $expr = $this->splitSQLIntoTokens($expr);
         return $processor->process($expr);
@@ -167,7 +167,7 @@ class PartitionDefinitionProcessor extends AbstractProcessor {
                     unset($last['storage']);
                     $parsed['sub_tree'][] = $last;
                     $parsed['base_expr'] = trim($base_expr);
-                    
+
                     $expr = $parsed['sub_tree'];
                     unset($last);
                     $currCategory = $prevCategory;
@@ -227,7 +227,7 @@ class PartitionDefinitionProcessor extends AbstractProcessor {
                     $parsed['sub_tree'] = $expr;
                     $base_expr = $token;
                     $expr = array($this->getReservedType($trim));
-                    
+
                     $currCategory = $upper;
                     continue 2;
                 }
@@ -314,7 +314,7 @@ class PartitionDefinitionProcessor extends AbstractProcessor {
 
                     $parsed['sub_tree'][] = $last;
                     $parsed['base_expr'] = trim($base_expr);
-                    
+
                     $expr = $parsed['sub_tree'];
                     unset($last);
 
@@ -334,9 +334,9 @@ class PartitionDefinitionProcessor extends AbstractProcessor {
                 case 'VALUES':
                 // we have parenthesis and have to process an expression/in-list
                     $last = $this->getBracketExpressionType($trim);
-                    
+
                     $res = $this->processExpressionList($trim);
-                    $last['sub_tree'] = (empty($res) ? false : $res); 
+                    $last['sub_tree'] = (empty($res) ? false : $res);
                     $expr[] = $last;
 
                     $last = array_pop($parsed['sub_tree']);
@@ -347,7 +347,7 @@ class PartitionDefinitionProcessor extends AbstractProcessor {
                     unset($last['storage']);
                     $parsed['sub_tree'][] = $last;
                     $parsed['base_expr'] = trim($base_expr);
-                    
+
                     $expr = $parsed['sub_tree'];
                     unset($last);
 
@@ -370,7 +370,7 @@ class PartitionDefinitionProcessor extends AbstractProcessor {
                             break;
                         }
                     }
-                    // else ?                    
+                    // else ?
                     break;
 
                 default:

--- a/src/PHPSQLParser/processors/PartitionOptionsProcessor.php
+++ b/src/PHPSQLParser/processors/PartitionOptionsProcessor.php
@@ -2,7 +2,7 @@
 /**
  * PartitionOptionsProcessor.php
  *
- * This file implements the processor for the PARTITION BY statements 
+ * This file implements the processor for the PARTITION BY statements
  * within CREATE TABLE.
  *
  * PHP version 5
@@ -48,25 +48,25 @@ use PHPSQLParser\utils\ExpressionType;
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class PartitionOptionsProcessor extends AbstractProcessor {
 
     protected function processExpressionList($unparsed) {
-        $processor = new ExpressionListProcessor();
+        $processor = new ExpressionListProcessor($this->options);
         $expr = $this->removeParenthesisFromStart($unparsed);
         $expr = $this->splitSQLIntoTokens($expr);
         return $processor->process($expr);
     }
 
     protected function processColumnList($unparsed) {
-        $processor = new ColumnListProcessor();
+        $processor = new ColumnListProcessor($this->options);
         $expr = $this->removeParenthesisFromStart($unparsed);
         return $processor->process($expr);
     }
 
     protected function processPartitionDefinition($unparsed) {
-        $processor = new PartitionDefinitionProcessor();
+        $processor = new PartitionDefinitionProcessor($this->options);
         $expr = $this->removeParenthesisFromStart($unparsed);
         $expr = $this->splitSQLIntoTokens($expr);
         return $processor->process($expr);
@@ -162,7 +162,7 @@ class PartitionOptionsProcessor extends AbstractProcessor {
                                 'storage' => substr($base_expr, 0, -strlen($token)));
 
                 $last = array_pop($parsed);
-                $last['by'] = trim($currCategory . ' ' . $upper); // $currCategory will be empty or LINEAR! 
+                $last['by'] = trim($currCategory . ' ' . $upper); // $currCategory will be empty or LINEAR!
                 $last['sub_tree'] = $expr;
                 $parsed[] = $last;
 
@@ -306,7 +306,7 @@ class PartitionOptionsProcessor extends AbstractProcessor {
                 case 'LIST_COLUMNS':
                 case 'RANGE_COLUMNS':
                 case 'KEY':
-                // the columnlist 
+                // the columnlist
                     $expr[] = array('expr_type' => ExpressionType::COLUMN_LIST, 'base_expr' => $trim,
                                     'sub_tree' => $this->processColumnList($trim));
 
@@ -338,7 +338,7 @@ class PartitionOptionsProcessor extends AbstractProcessor {
                             break;
                         }
                     }
-                    // else ?                    
+                    // else ?
                     break;
 
                 default:

--- a/src/PHPSQLParser/processors/RecordProcessor.php
+++ b/src/PHPSQLParser/processors/RecordProcessor.php
@@ -2,7 +2,7 @@
 /**
  * RecordProcessor.php
  *
- * This file implements a processor, which processes records of data 
+ * This file implements a processor, which processes records of data
  * for an INSERT statement.
  *
  * PHP version 5
@@ -47,12 +47,12 @@ namespace PHPSQLParser\processors;
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class RecordProcessor extends AbstractProcessor {
 
     protected function processExpressionList($unparsed) {
-        $processor = new ExpressionListProcessor();
+        $processor = new ExpressionListProcessor($this->options);
         return $processor->process($unparsed);
     }
 

--- a/src/PHPSQLParser/processors/ReferenceDefinitionProcessor.php
+++ b/src/PHPSQLParser/processors/ReferenceDefinitionProcessor.php
@@ -154,7 +154,7 @@ class ReferenceDefinitionProcessor extends AbstractProcessor {
                 case 'REFERENCES':
                     if ($upper[0] === '(' && substr($upper, -1) === ')') {
                         # index_col_name list
-                        $processor = new IndexColumnListProcessor();
+                        $processor = new IndexColumnListProcessor($this->options);
                         $cols = $processor->process($this->removeParenthesisFromStart($trim));
                         $expr['sub_tree'][] = array('expr_type' => ExpressionType::COLUMN_LIST, 'base_expr' => $trim,
                                                     'sub_tree' => $cols);

--- a/src/PHPSQLParser/processors/SQLChunkProcessor.php
+++ b/src/PHPSQLParser/processors/SQLChunkProcessor.php
@@ -65,119 +65,119 @@ class SQLChunkProcessor extends AbstractProcessor {
         if (!empty($out['BRACKET'])) {
             // TODO: this field should be a global STATEMENT field within the output
             // we could add all other categories as sub_tree, it could also work with multipe UNIONs
-            $processor = new BracketProcessor();
+            $processor = new BracketProcessor($this->options);
             $out['BRACKET'] = $processor->process($out['BRACKET']);
         }
         if (!empty($out['CREATE'])) {
-            $processor = new CreateProcessor();
+            $processor = new CreateProcessor($this->options);
             $out['CREATE'] = $processor->process($out['CREATE']);
         }
         if (!empty($out['TABLE'])) {
-            $processor = new TableProcessor();
+            $processor = new TableProcessor($this->options);
             $out['TABLE'] = $processor->process($out['TABLE']);
             $this->moveLIKE($out);
         }
         if (!empty($out['INDEX'])) {
-            $processor = new IndexProcessor();
+            $processor = new IndexProcessor($this->options);
             $out['INDEX'] = $processor->process($out['INDEX']);
         }
         if (!empty($out['EXPLAIN'])) {
-            $processor = new ExplainProcessor();
+            $processor = new ExplainProcessor($this->options);
             $out['EXPLAIN'] = $processor->process($out['EXPLAIN'], array_keys($out));
         }
         if (!empty($out['DESCRIBE'])) {
-            $processor = new DescribeProcessor();
+            $processor = new DescribeProcessor($this->options);
             $out['DESCRIBE'] = $processor->process($out['DESCRIBE'], array_keys($out));
         }
         if (!empty($out['DESC'])) {
-            $processor = new DescProcessor();
+            $processor = new DescProcessor($this->options);
             $out['DESC'] = $processor->process($out['DESC'], array_keys($out));
         }
         if (!empty($out['SELECT'])) {
-            $processor = new SelectProcessor();
+            $processor = new SelectProcessor($this->options);
             $out['SELECT'] = $processor->process($out['SELECT']);
         }
         if (!empty($out['FROM'])) {
-            $processor = new FromProcessor();
+            $processor = new FromProcessor($this->options);
             $out['FROM'] = $processor->process($out['FROM']);
         }
         if (!empty($out['USING'])) {
-            $processor = new UsingProcessor();
+            $processor = new UsingProcessor($this->options);
             $out['USING'] = $processor->process($out['USING']);
         }
         if (!empty($out['UPDATE'])) {
-            $processor = new UpdateProcessor();
+            $processor = new UpdateProcessor($this->options);
             $out['UPDATE'] = $processor->process($out['UPDATE']);
         }
         if (!empty($out['GROUP'])) {
             // set empty array if we have partial SQL statement
-            $processor = new GroupByProcessor();
+            $processor = new GroupByProcessor($this->options);
             $out['GROUP'] = $processor->process($out['GROUP'], isset($out['SELECT']) ? $out['SELECT'] : array());
         }
         if (!empty($out['ORDER'])) {
             // set empty array if we have partial SQL statement
-            $processor = new OrderByProcessor();
+            $processor = new OrderByProcessor($this->options);
             $out['ORDER'] = $processor->process($out['ORDER'], isset($out['SELECT']) ? $out['SELECT'] : array());
         }
         if (!empty($out['LIMIT'])) {
-            $processor = new LimitProcessor();
+            $processor = new LimitProcessor($this->options);
             $out['LIMIT'] = $processor->process($out['LIMIT']);
         }
         if (!empty($out['WHERE'])) {
-            $processor = new WhereProcessor();
+            $processor = new WhereProcessor($this->options);
             $out['WHERE'] = $processor->process($out['WHERE']);
         }
         if (!empty($out['HAVING'])) {
-            $processor = new HavingProcessor();
+            $processor = new HavingProcessor($this->options);
             $out['HAVING'] = $processor->process($out['HAVING'], isset($out['SELECT']) ? $out['SELECT'] : array());
         }
         if (!empty($out['SET'])) {
-            $processor = new SetProcessor();
+            $processor = new SetProcessor($this->options);
             $out['SET'] = $processor->process($out['SET'], isset($out['UPDATE']));
         }
         if (!empty($out['DUPLICATE'])) {
-            $processor = new DuplicateProcessor();
+            $processor = new DuplicateProcessor($this->options);
             $out['ON DUPLICATE KEY UPDATE'] = $processor->process($out['DUPLICATE']);
             unset($out['DUPLICATE']);
         }
         if (!empty($out['INSERT'])) {
-            $processor = new InsertProcessor();
+            $processor = new InsertProcessor($this->options);
             $out = $processor->process($out);
         }
         if (!empty($out['REPLACE'])) {
-            $processor = new ReplaceProcessor();
+            $processor = new ReplaceProcessor($this->options);
             $out = $processor->process($out);
         }
         if (!empty($out['DELETE'])) {
-            $processor = new DeleteProcessor();
+            $processor = new DeleteProcessor($this->options);
             $out = $processor->process($out);
         }
         if (!empty($out['VALUES'])) {
-            $processor = new ValuesProcessor();
+            $processor = new ValuesProcessor($this->options);
             $out = $processor->process($out);
         }
         if (!empty($out['INTO'])) {
-            $processor = new IntoProcessor();
+            $processor = new IntoProcessor($this->options);
             $out = $processor->process($out);
         }
         if (!empty($out['DROP'])) {
-            $processor = new DropProcessor();
+            $processor = new DropProcessor($this->options);
             $out['DROP'] = $processor->process($out['DROP']);
         }
         if (!empty($out['RENAME'])) {
-            $processor = new RenameProcessor();
+            $processor = new RenameProcessor($this->options);
             $out['RENAME'] = $processor->process($out['RENAME']);
         }
         if (!empty($out['SHOW'])) {
-            $processor = new ShowProcessor();
+            $processor = new ShowProcessor($this->options);
             $out['SHOW'] = $processor->process($out['SHOW']);
         }
         if (!empty($out['OPTIONS'])) {
-            $processor = new OptionsProcessor();
+            $processor = new OptionsProcessor($this->options);
             $out['OPTIONS'] = $processor->process($out['OPTIONS']);
         }
         if (!empty($out['WITH'])) {
-        	$processor = new WithProcessor();
+        	$processor = new WithProcessor($this->options);
         	$out['WITH'] = $processor->process($out['WITH']);
         }
         return $out;

--- a/src/PHPSQLParser/processors/SelectExpressionProcessor.php
+++ b/src/PHPSQLParser/processors/SelectExpressionProcessor.php
@@ -34,19 +34,19 @@ namespace PHPSQLParser\processors;
 use PHPSQLParser\utils\ExpressionType;
 
 /**
- * 
+ *
  * This class processes the SELECT expressions.
- * 
+ *
  * @author arothe
- * 
+ *
  */
 class SelectExpressionProcessor extends AbstractProcessor {
 
     protected function processExpressionList($unparsed) {
-        $processor = new ExpressionListProcessor();
+        $processor = new ExpressionListProcessor($this->options);
         return $processor->process($unparsed);
     }
-        
+
     /**
      * This fuction processes each SELECT clause.
      * We determine what (if any) alias
@@ -60,8 +60,8 @@ class SelectExpressionProcessor extends AbstractProcessor {
         }
 
         /*
-         * Determine if there is an explicit alias after the AS clause. 
-         * If AS is found, then the next non-whitespace token is captured as the alias. 
+         * Determine if there is an explicit alias after the AS clause.
+         * If AS is found, then the next non-whitespace token is captured as the alias.
          * The tokens after (and including) the AS are removed.
          */
         $base_expr = "";
@@ -105,8 +105,8 @@ class SelectExpressionProcessor extends AbstractProcessor {
             $alias['no_quotes'] = $this->revokeQuotation($alias['name']);
             $alias['name'] = trim($alias['name']);
             $alias['base_expr'] = trim($alias['base_expr']);
-        }    
-        
+        }
+
         $stripped = $this->processExpressionList($stripped);
 
         // TODO: the last part can also be a comment, don't use array_pop
@@ -134,7 +134,7 @@ class SelectExpressionProcessor extends AbstractProcessor {
         }
 
         $base_expr = $expression;
-        
+
         // TODO: this is always done with $stripped, how we do it twice?
         $processed = $this->processExpressionList($tokens);
 

--- a/src/PHPSQLParser/processors/SetProcessor.php
+++ b/src/PHPSQLParser/processors/SetProcessor.php
@@ -34,16 +34,16 @@ namespace PHPSQLParser\processors;
 use PHPSQLParser\utils\ExpressionType;
 
 /**
- * 
+ *
  * This class processes the SET statements.
- * 
+ *
  * @author arothe
- * 
+ *
  */
 class SetProcessor extends AbstractProcessor {
 
     protected function processExpressionList($tokens) {
-        $processor = new ExpressionListProcessor();
+        $processor = new ExpressionListProcessor($this->options);
         return $processor->process($tokens);
     }
 
@@ -53,9 +53,9 @@ class SetProcessor extends AbstractProcessor {
      */
     protected function processAssignment($base_expr) {
         $assignment = $this->processExpressionList($this->splitSQLIntoTokens($base_expr));
-        
+
         // TODO: if the left side of the assignment is a reserved keyword, it should be changed to colref
-        
+
         return array('expr_type' => ExpressionType::EXPRESSION, 'base_expr' => trim($base_expr),
                      'sub_tree' => (empty($assignment) ? false : $assignment));
     }

--- a/src/PHPSQLParser/processors/ShowProcessor.php
+++ b/src/PHPSQLParser/processors/ShowProcessor.php
@@ -31,22 +31,24 @@
  */
 
 namespace PHPSQLParser\processors;
+use PHPSQLParser\Options;
 use PHPSQLParser\utils\ExpressionType;
 use PHPSQLParser\utils\PHPSQLParserConstants;
 
 /**
- * 
+ *
  * This class processes the SHOW statements.
- * 
+ *
  * @author arothe
- * 
+ *
  */
 class ShowProcessor extends AbstractProcessor {
 
     private $limitProcessor;
 
-    public function __construct() {
-        $this->limitProcessor = new LimitProcessor();
+    public function __construct(Options $options) {
+        parent::__construct($options);
+        $this->limitProcessor = new LimitProcessor($options);
     }
 
     public function process($tokens) {

--- a/src/PHPSQLParser/processors/TableProcessor.php
+++ b/src/PHPSQLParser/processors/TableProcessor.php
@@ -47,7 +47,7 @@ use PHPSQLParser\utils\ExpressionType;
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class TableProcessor extends AbstractProcessor {
 
@@ -64,12 +64,12 @@ class TableProcessor extends AbstractProcessor {
     }
 
     protected function processPartitionOptions($tokens) {
-        $processor = new PartitionOptionsProcessor();
+        $processor = new PartitionOptionsProcessor($this->options);
         return $processor->process($tokens);
     }
 
     protected function processCreateDefinition($tokens) {
-        $processor = new CreateDefinitionProcessor();
+        $processor = new CreateDefinitionProcessor($this->options);
         return $processor->process($tokens);
     }
 

--- a/src/PHPSQLParser/processors/UnionProcessor.php
+++ b/src/PHPSQLParser/processors/UnionProcessor.php
@@ -40,24 +40,23 @@
  */
 
 namespace PHPSQLParser\processors;
-use PHPSQLParser\utils\ExpressionType;
 
 /**
  * This class processes the UNION statements.
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class UnionProcessor extends AbstractProcessor {
 
     protected function processDefault($token) {
-        $processor = new DefaultProcessor();
+        $processor = new DefaultProcessor($this->options);
         return $processor->process($token);
     }
 
     protected function processSQL($token) {
-        $processor = new SQLProcessor();
+        $processor = new SQLProcessor($this->options);
         return $processor->process($token);
     }
 

--- a/src/PHPSQLParser/processors/ValuesProcessor.php
+++ b/src/PHPSQLParser/processors/ValuesProcessor.php
@@ -47,17 +47,17 @@ use PHPSQLParser\utils\ExpressionType;
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class ValuesProcessor extends AbstractProcessor {
 
     protected function processExpressionList($unparsed) {
-        $processor = new ExpressionListProcessor();
+        $processor = new ExpressionListProcessor($this->options);
         return $processor->process($unparsed);
     }
 
     protected function processRecord($unparsed) {
-        $processor = new RecordProcessor();
+        $processor = new RecordProcessor($this->options);
         return $processor->process($unparsed);
     }
 
@@ -71,12 +71,12 @@ class ValuesProcessor extends AbstractProcessor {
             if ($this->isWhitespaceToken($v)) {
                 continue;
             }
-            
+
             if ($this->isCommentToken($v)) {
                  $parsed[] = parent::processComment($v);
                  continue;
             }
-            
+
             $base_expr .= $v;
             $trim = trim($v);
 

--- a/src/PHPSQLParser/processors/WithProcessor.php
+++ b/src/PHPSQLParser/processors/WithProcessor.php
@@ -34,24 +34,24 @@ namespace PHPSQLParser\processors;
 use PHPSQLParser\utils\ExpressionType;
 
 /**
- * 
+ *
  * This class processes Oracle's WITH statements.
- * 
+ *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- * 
+ *
  */
 class WithProcessor extends AbstractProcessor {
 
     protected function processTopLevel($sql) {
-    	$processor = new DefaultProcessor();
+    	$processor = new DefaultProcessor($this->options);
     	return $processor->process($sql);
     }
-    
+
     protected function buildTableName($token) {
     	return array('expr_type' => ExpressionType::TEMPORARY_TABLE, 'name'=>$token, 'base_expr' => $token, 'no_quotes' => $this->revokeQuotation($token));
     }
-    
+
     public function process($tokens) {
     	$out = array();
         $resultList = array();
@@ -62,7 +62,7 @@ class WithProcessor extends AbstractProcessor {
         foreach ($tokens as $token) {
         	$base_expr .= $token;
             $upper = strtoupper(trim($token));
-			
+
             if ($this->isWhitespaceToken($token)) {
                 continue;
             }
@@ -77,7 +77,7 @@ class WithProcessor extends AbstractProcessor {
             		$category = 'TABLENAME';
             		break;
             	}
-            	
+
             	$resultList[] = array('expr_type' => ExpressionType::RESERVED, 'base_expr' => $trim);
             	$category = $upper;
                 break;
@@ -85,26 +85,26 @@ class WithProcessor extends AbstractProcessor {
             case ',':
             	// ignore
             	$base_expr = '';
-            	break;    
-                
+            	break;
+
             default:
                 switch ($prev) {
                 	case 'AS':
-                		// it follows a parentheses pair	
+                		// it follows a parentheses pair
                 		$subtree = $this->processTopLevel($this->removeParenthesisFromStart($token));
                 		$resultList[] = array('expr_type' => ExpressionType::BRACKET_EXPRESSION, 'base_expr' => $trim, 'sub_tree' => $subtree);
-                		
+
                 		$out[] = array('expr_type' => ExpressionType::SUBQUERY_FACTORING, 'base_expr' => trim($base_expr), 'sub_tree' => $resultList);
                 		$resultList = array();
                 		$category = '';
                 	break;
-                	
+
                 	case '':
                 		// we have the name of the table
                 		$resultList[] = $this->buildTableName($trim);
                 		$category = 'TABLENAME';
                 		break;
-                		
+
                 default:
                 // ignore
                     break;

--- a/src/PHPSQLParser/utils/ExpressionToken.php
+++ b/src/PHPSQLParser/utils/ExpressionToken.php
@@ -2,6 +2,7 @@
 
 namespace PHPSQLParser\utils;
 
+use PHPSQLParser\Options;
 use PHPSQLParser\processors\DefaultProcessor;
 
 class ExpressionToken {
@@ -55,10 +56,10 @@ class ExpressionToken {
         return $idx !== false ? $this->token[$idx] : $this->token;
     }
 
-    public function setNoQuotes($token, $qchars = null) {
-        $this->noQuotes = ($token === null) ? null : $this->revokeQuotation($token);
+    public function setNoQuotes($token, $qchars = null, Options $options) {
+        $this->noQuotes = ($token === null) ? null : $this->revokeQuotation($token, $options);
     }
-    
+
     public function setTokenType($type) {
         $this->tokenType = $type;
     }
@@ -116,7 +117,7 @@ class ExpressionToken {
     public function isVariable() {
         return $this->tokenType === ExpressionType::GLOBAL_VARIABLE || $this->tokenType === ExpressionType::LOCAL_VARIABLE || $this->tokenType === ExpressionType::USER_VARIABLE;
     }
-    
+
     public function isAggregateFunction() {
         return $this->tokenType === ExpressionType::AGGREGATE_FUNCTION;
     }
@@ -141,17 +142,17 @@ class ExpressionToken {
         return $this->tokenType === ExpressionType::SUBQUERY;
     }
 
-    private function revokeQuotation($token) {
-        $defProc = new DefaultProcessor();
+    private function revokeQuotation($token, Options $options) {
+        $defProc = new DefaultProcessor($options);
         return $defProc->revokeQuotation($token);
     }
-    
+
     public function toArray() {
         $result = array();
         $result['expr_type'] = $this->tokenType;
         $result['base_expr'] = $this->token;
         if (!empty($this->noQuotes)) {
-            $result['no_quotes'] = $this->noQuotes;   
+            $result['no_quotes'] = $this->noQuotes;
         }
         $result['sub_tree'] = $this->subTree;
         return $result;


### PR DESCRIPTION
I'm not sure if I understood the code correctly, but in my opinion the ONE and TWO in the *_PARAM_PARAMETERS are consistent comparing to all the other sub tree handling, so I just optionally modified the MULTIPLE branch. 

I hope this is what was meant in #207 . Regarding the passing of the object - I didn't want to make it statically accessible, because it would change state of all the SQLParser instances globally, which I'm not sure if that would be a good idea.