### PR TITLE
Fixed when REPLACE is used without INTO

### DIFF
--- a/src/PHPSQLParser/processors/InsertProcessor.php
+++ b/src/PHPSQLParser/processors/InsertProcessor.php
@@ -85,6 +85,7 @@ class InsertProcessor extends AbstractProcessor {
                 continue;
 
             case 'INSERT':
+            case 'REPLACE':
                 continue;
 
             default:
@@ -148,8 +149,8 @@ class InsertProcessor extends AbstractProcessor {
         $parsed = array_merge($parsed, $key);
         unset($tokenList['INTO']);
 
-        if ($table === '' && $token_category === 'INSERT') {
-            list($table, $cols, $key) = $this->processKeyword('INSERT', $tokenList);
+        if ($table === '' && in_array($token_category, array('INSERT', 'REPLACE'))) {
+            list($table, $cols, $key) = $this->processKeyword($token_category, $tokenList);
         }
 
         $parsed[] = array('expr_type' => ExpressionType::TABLE, 'table' => $table,


### PR DESCRIPTION
Before REPLACE INTO used to get parsed-

```sql
REPLACE INTO table (a,b,c) VALUES (1,2,3)
```

but REPLACE without INTO threw error.

```sql
REPLACE table (a,b,c) VALUES (1,2,3)
```