### PR TITLE
Fix UnionProcessor instantiation

### DIFF
--- a/src/PHPSQLParser/processors/FromProcessor.php
+++ b/src/PHPSQLParser/processors/FromProcessor.php
@@ -117,7 +117,7 @@ class FromProcessor extends AbstractProcessor {
                 $res['expr_type'] = ExpressionType::SUBQUERY;
             } else {
                 $tmp = $this->splitSQLIntoTokens($parseInfo['expression']);
-                $unionProcessor = new UnionProcessor();
+                $unionProcessor = new UnionProcessor($this->options);
                 $unionQueries = $unionProcessor->process($tmp);
 
                 // If there was no UNION or UNION ALL in the query, then the query is


### PR DESCRIPTION
When processing a from portion of the query with a union join, the loading of the UnionProcessory requires (via the AbstractProcessor) that the constructor has the options object passed to it. This fixes that issue.

I did not conduct any unit tests, but doing this resolve a parsing error we had. Exact error was:

Argument 1 passed to PHPSQLParser\processors\AbstractProcessor::__construct() must be an instance of PHPSQLParser\Options, none given, called in /vendor/greenlion/php-sql-parser/src/PHPSQLParser/processors/FromProcessor.php on line 120 and defined (/vendor/greenlion/php-sql-parser/src/PHPSQLParser/processors/AbstractProcessor.php : 67);