### PR TITLE
add the ability to parse reserved words in the WHERE clause

### DIFF
--- a/src/PHPSQLParser/builders/WhereBracketExpressionBuilder.php
+++ b/src/PHPSQLParser/builders/WhereBracketExpressionBuilder.php
@@ -31,12 +31,12 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * @author    André Rothe <andre.rothe@phosco.info>
  * @copyright 2010-2014 Justin Swanhart and André Rothe
  * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
  * @version   SVN: $Id$
- * 
+ *
  */
 
 namespace PHPSQLParser\builders;
@@ -44,12 +44,12 @@ use PHPSQLParser\exceptions\UnableToCreateSQLException;
 use PHPSQLParser\utils\ExpressionType;
 
 /**
- * This class implements the builder for bracket expressions within the WHERE part. 
+ * This class implements the builder for bracket expressions within the WHERE part.
  * You can overwrite all functions to achieve another handling.
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class WhereBracketExpressionBuilder implements Builder {
 
@@ -88,6 +88,11 @@ class WhereBracketExpressionBuilder implements Builder {
         return $builder->build($parsed);
     }
 
+    protected function buildReserved($parsed) {
+      $builder = new ReservedBuilder();
+      return $builder->build($parsed);
+    }
+
     public function build(array $parsed) {
         if ($parsed['expr_type'] !== ExpressionType::BRACKET_EXPRESSION) {
             return "";
@@ -103,7 +108,8 @@ class WhereBracketExpressionBuilder implements Builder {
             $sql .= $this->buildWhereExpression($v);
             $sql .= $this->build($v);
             $sql .= $this->buildUserVariable($v);
-
+            $sql .= $this->buildReserved($v);
+            
             if ($len == strlen($sql)) {
                 throw new UnableToCreateSQLException('WHERE expression subtree', $k, $v, 'expr_type');
             }

--- a/src/PHPSQLParser/builders/WhereBuilder.php
+++ b/src/PHPSQLParser/builders/WhereBuilder.php
@@ -31,24 +31,24 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * @author    André Rothe <andre.rothe@phosco.info>
  * @copyright 2010-2014 Justin Swanhart and André Rothe
  * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
  * @version   SVN: $Id$
- * 
+ *
  */
 
 namespace PHPSQLParser\builders;
 use PHPSQLParser\exceptions\UnableToCreateSQLException;
 
 /**
- * This class implements the builder for the WHERE part. 
+ * This class implements the builder for the WHERE part.
  * You can overwrite all functions to achieve another handling.
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class WhereBuilder implements Builder {
 
@@ -97,6 +97,11 @@ class WhereBuilder implements Builder {
         return $builder->build($parsed);
     }
 
+    protected function buildReserved($parsed) {
+      $builder = new ReservedBuilder();
+      return $builder->build($parsed);
+    }
+
     public function build(array $parsed) {
         $sql = "WHERE ";
         foreach ($parsed as $k => $v) {
@@ -111,7 +116,8 @@ class WhereBuilder implements Builder {
             $sql .= $this->buildWhereExpression($v);
             $sql .= $this->buildWhereBracketExpression($v);
             $sql .= $this->buildUserVariable($v);
-
+            $sql .= $this->buildReserved($v);
+            
             if (strlen($sql) == $len) {
                 throw new UnableToCreateSQLException('WHERE', $k, $v, 'expr_type');
             }

--- a/src/PHPSQLParser/builders/WhereExpressionBuilder.php
+++ b/src/PHPSQLParser/builders/WhereExpressionBuilder.php
@@ -31,12 +31,12 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * @author    André Rothe <andre.rothe@phosco.info>
  * @copyright 2010-2014 Justin Swanhart and André Rothe
  * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
  * @version   SVN: $Id$
- * 
+ *
  */
 
 namespace PHPSQLParser\builders;
@@ -44,12 +44,12 @@ use PHPSQLParser\exceptions\UnableToCreateSQLException;
 use PHPSQLParser\utils\ExpressionType;
 
 /**
- * This class implements the builder for expressions within the WHERE part. 
+ * This class implements the builder for expressions within the WHERE part.
  * You can overwrite all functions to achieve another handling.
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class WhereExpressionBuilder implements Builder {
 
@@ -62,41 +62,46 @@ class WhereExpressionBuilder implements Builder {
         $builder = new ConstantBuilder();
         return $builder->build($parsed);
     }
-    
+
     protected function buildOperator($parsed) {
         $builder = new OperatorBuilder();
         return $builder->build($parsed);
     }
-    
+
     protected function buildFunction($parsed) {
         $builder = new FunctionBuilder();
         return $builder->build($parsed);
     }
-    
+
     protected function buildInList($parsed) {
         $builder = new InListBuilder();
         return $builder->build($parsed);
     }
-    
+
     protected function buildWhereExpression($parsed) {
         return $this->build($parsed);
     }
-    
+
     protected function buildWhereBracketExpression($parsed) {
         $builder = new WhereBracketExpressionBuilder();
         return $builder->build($parsed);
     }
-    
+
     protected function buildUserVariable($parsed) {
         $builder = new UserVariableBuilder();
         return $builder->build($parsed);
     }
-    
+
     protected function buildSubQuery($parsed) {
         $builder = new SubQueryBuilder();
         return $builder->build($parsed);
     }
-    
+
+    protected function buildReserved($parsed) {
+      $builder = new ReservedBuilder();
+      return $builder->build($parsed);
+    }
+
     public function build(array $parsed) {
         if ($parsed['expr_type'] !== ExpressionType::EXPRESSION) {
             return "";
@@ -113,7 +118,8 @@ class WhereExpressionBuilder implements Builder {
             $sql .= $this->buildWhereBracketExpression($v);
             $sql .= $this->buildUserVariable($v);
             $sql .= $this->buildSubQuery($v);
-
+            $sql .= $this->buildReserved($v);
+            
             if ($len == strlen($sql)) {
                 throw new UnableToCreateSQLException('WHERE expression subtree', $k, $v, 'expr_type');
             }
@@ -124,6 +130,6 @@ class WhereExpressionBuilder implements Builder {
         $sql = substr($sql, 0, -1);
         return $sql;
     }
-    
+
 }
 ?>


### PR DESCRIPTION
```
<?php
  require 'parser/src/PHPSQLParser.php';
  require 'parser/src/PHPSQLCreator.php';
  $parser = new PHPSQLParser();
  $creator = new PHPSQLCreator();

  $q = 'SELECT * FROM myTable WHERE startTime > NOW() - INTERVAL 30 MINUTE';
  $ast = $parser->parse($q);

  try {
    $sql = $creator->create($ast);
    echo $sql;
  } catch (Exception $e) {
    echo $e->getMessage();
  }
```


results in:
`unknown [expr_type] = reserved in "WHERE" [4] `