### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ PHP-SQL-Parser
 A pure PHP SQL (non validating) parser w/ focus on MySQL dialect of SQL
 
 
-###Download
+### Download
 
  [GitHub Wiki](https://github.com/greenlion/PHP-SQL-Parser/wiki/Downloads)<br>
     
-###Full support for the MySQL dialect for the following statement types
+### Full support for the MySQL dialect for the following statement types
 
     SELECT
     INSERT
@@ -24,27 +24,27 @@ A pure PHP SQL (non validating) parser w/ focus on MySQL dialect of SQL
     EXPLAIN
     DESCRIBE
 
-###Other SQL statement types
+### Other SQL statement types
 
 Other statements are returned as an array of tokens. This is not as structured as the information available about the above types. See the [ParserManual](https://github.com/greenlion/PHP-SQL-Parser/wiki/Parser-Manual) for more information.
 
-###Other SQL dialects
+### Other SQL dialects
 
 Since the MySQL SQL dialect is very close to SQL-92, this should work for most database applications that need a SQL parser. If using another database dialect, then you may want to change the reserved words - see the [ParserManual](https://github.com/greenlion/PHP-SQL-Parser/wiki/Parser-Manual). It supports UNION, subqueries and compound statements.
 
-###External dependencies
+### External dependencies
 
 The parser is a self contained class. It has no external dependencies. The parser uses a small amount of regex.
 
-###Focus
+### Focus
 
 The focus of the parser is complete and accurate support for the MySQL SQL dialect. The focus is not on optimizing for performance. It is expected that you will present syntactically valid queries.
 
-###Manual
+### Manual
 
 [ParserManual](https://github.com/greenlion/PHP-SQL-Parser/wiki/Parser-Manual) - Check out the manual.
 
-###Example Output
+### Example Output
 
 **Example Query**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
