### PR TITLE
Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: php
+
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_script:
+  - composer install
+
+script: vendor/bin/phpunit --configuration phpunit.xml
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/greenlion/PHP-SQL-Parser.svg?branch=master)](https://travis-ci.org/greenlion/PHP-SQL-Parser)
+
 PHP-SQL-Parser
 ==============
 


### PR DESCRIPTION
#257 
Added .travis.yml configuration file.
One step is required. Owner of this repository must register at [Travis CI](https://docs.travis-ci.com/user/getting-started/)