### PR TITLE
Set to match InsertProcessor prevent Fatal Error

### DIFF
--- a/src/PHPSQLParser/processors/ReplaceProcessor.php
+++ b/src/PHPSQLParser/processors/ReplaceProcessor.php
@@ -50,8 +50,8 @@ namespace PHPSQLParser\processors;
  */
 class ReplaceProcessor extends InsertProcessor {
 
-    public function process($tokenList) {
-        return parent::process($tokenList, 'REPLACE');
+    public function process($tokenList, $token_category = 'REPLACE') {
+        return parent::process($tokenList, $token_category);
     }
 
 }


### PR DESCRIPTION
Fatal error: Declaration of PHPSQLParser\processors\ReplaceProcessor::process($tokenList) must be compatible with PHPSQLParser\processors\InsertProcessor::process($tokenList, $token_category = 'INSERT') in /www/laravel/book/vendor/greenlion/php-sql-parser/src/PHPSQLParser/processors/ReplaceProcessor.php on line 52