### PR TITLE
Set to match SetProcessor to prevent Fatal Error

### DIFF
--- a/src/PHPSQLParser/processors/DuplicateProcessor.php
+++ b/src/PHPSQLParser/processors/DuplicateProcessor.php
@@ -41,8 +41,8 @@ namespace PHPSQLParser\processors;
  */
 class DuplicateProcessor extends SetProcessor {
 
-    public function process($tokens) {
-        return parent::process($tokens, false);
+    public function process($tokens, $isUpdate = false) {
+        return parent::process($tokens, $isUpdate);
     }
 
 }


### PR DESCRIPTION
Fatal error: Declaration of PHPSQLParser\processors\DuplicateProcessor::process($tokens) must be compatible with PHPSQLParser\processors\SetProcessor::process($tokens, $isUpdate = false)