### PR TITLE
Order by positions

### DIFF
--- a/src/PHPSQLParser/builders/OrderByBuilder.php
+++ b/src/PHPSQLParser/builders/OrderByBuilder.php
@@ -83,6 +83,11 @@ class OrderByBuilder implements Builder {
         return $builder->build($parsed);
     }
     
+    protected function buildPosition($parsed) {
+        $builder = new PositionBuilder();
+        return $builder->build($parsed);
+    }
+
     public function build(array $parsed) {
         $sql = "";
         foreach ($parsed as $k => $v) {
@@ -93,6 +98,7 @@ class OrderByBuilder implements Builder {
             $sql .= $this->buildExpression($v);
             $sql .= $this->buildBracketExpression($v);
             $sql .= $this->buildReserved($v);
+            $sql .= $this->buildPosition($v);
             
             if ($len == strlen($sql)) {
                 throw new UnableToCreateSQLException('ORDER', $k, $v, 'expr_type');

--- a/tests/cases/creator/orderByPositionTest.php
+++ b/tests/cases/creator/orderByPositionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Test the support for positions in ORDER BY expressions.
+ */
+
+namespace PHPSQLParser\Test\Parser;
+use PHPSQLParser\PHPSQLParser;
+use PHPSQLParser\PHPSQLCreator;
+
+class OrderByPositionTest extends \PHPSQLParser\Test\AbstractTestCase {
+    public function testOrderByPosition() {
+        $query = "SELECT c1, c2 FROM t ORDER BY 1";
+
+        $parsed = $this->parser->parse($query);
+        $created = $this->creator->create($parsed);
+        $expected = getExpectedValue(dirname(__FILE__), 'orderbyposition.sql', false);
+        $this->assertEquals($expected, $created, 'creating ORDER BY with positions is not supported');
+    }
+}

--- a/tests/expected/creator/orderbyposition.sql
+++ b/tests/expected/creator/orderbyposition.sql
@@ -1,0 +1,1 @@
+SELECT c1, c2 FROM t ORDER BY 1


### PR DESCRIPTION
This pull request makes it possible to use a column position in `ORDER BY` clauses. This is already supported for`GROUP BY` clauses, but MySQL also allows column positions in `ORDER BY`.