### PR TITLE
Prevent Undefined offset error

### DIFF
--- a/src/PHPSQLParser/processors/SQLProcessor.php
+++ b/src/PHPSQLParser/processors/SQLProcessor.php
@@ -62,7 +62,8 @@ class SQLProcessor extends SQLChunkProcessor {
         $out = false;
 
 	// $tokens may come as a numeric indexed array starting with an index greater than 0 (or as a boolean)
-        if ( $tokenCount = count($tokens) ){
+	$tokenCount = count($tokens);
+        if ( is_array($tokens) ){
           $tokens = array_values($tokens);
         }
         for ($tokenNumber = 0; $tokenNumber < $tokenCount; ++$tokenNumber) {

--- a/src/PHPSQLParser/processors/SQLProcessor.php
+++ b/src/PHPSQLParser/processors/SQLProcessor.php
@@ -61,7 +61,10 @@ class SQLProcessor extends SQLChunkProcessor {
         $skip_next = 0;
         $out = false;
 
-        $tokenCount = count($tokens);
+	// $tokens may come as a numeric indexed array starting with an index greater than 0 (or as a boolean)
+        if ( $tokenCount = count($tokens) ){
+          $tokens = array_values($tokens);
+        }
         for ($tokenNumber = 0; $tokenNumber < $tokenCount; ++$tokenNumber) {
 
             $token = $tokens[$tokenNumber];


### PR DESCRIPTION
For some reason the argument `$tokens` comes sometime as a numeric array starting with an index greater than 0. In this case the loop with `$tokenNumber` starting at 0 will not be able to read the token and will throw an error `Undefined offset`