### PR TITLE
Fix for issue 233 comments not parsing when they have a quote

### DIFF
--- a/src/PHPSQLParser/lexer/PHPSQLLexer.php
+++ b/src/PHPSQLParser/lexer/PHPSQLLexer.php
@@ -212,6 +212,7 @@ class PHPSQLLexer {
         $cnt = count($tokens);
         $comment = false;
         $in_string = false;
+        $inline = false;
         while ($i < $cnt) {
 
             if (!isset($tokens[$i])) {
@@ -220,7 +221,7 @@ class PHPSQLLexer {
             }
 
             $token = $tokens[$i];
-            if($token == "\"" || $token == "'") {
+            if($comment === false && ($token == "\"" || $token == "'")) {
                 $in_string = !$in_string;
             }
             if(!$in_string) {


### PR DESCRIPTION
Fixes failing issue233Test
Ignore string rules when in comment