### PR TITLE
Remove duplicate switch cases for code clarity

### DIFF
--- a/src/PHPSQLParser/processors/ExpressionListProcessor.php
+++ b/src/PHPSQLParser/processors/ExpressionListProcessor.php
@@ -312,7 +312,6 @@ class ExpressionListProcessor extends AbstractProcessor {
                 case 'AND':
                 case '&&':
                 case 'BETWEEN':
-                case 'AND':
                 case 'BINARY':
                 case '&':
                 case '~':

--- a/src/PHPSQLParser/processors/SQLProcessor.php
+++ b/src/PHPSQLParser/processors/SQLProcessor.php
@@ -494,7 +494,6 @@ class SQLProcessor extends SQLChunkProcessor {
 
             case '':
             case ',':
-            case ';':
                 break;
 
             default:


### PR DESCRIPTION
If there are duplicate switch cases, only the earliest one is used.

On line 444 of SQLProcessor, `case ';'` was a `continue 2;` instead.

Detected via static analysis (no other issues of the same type were seen)