### PR TITLE
continue; targetting a switch got deprecated - replaced with break;

### DIFF
--- a/src/PHPSQLParser/processors/FromProcessor.php
+++ b/src/PHPSQLParser/processors/FromProcessor.php
@@ -237,7 +237,7 @@ class FromProcessor extends AbstractProcessor {
                 $parseInfo['alias']['name'] = $str;
                 $parseInfo['alias']['no_quotes'] = $this->revokeQuotation($str);
                 $parseInfo['alias']['base_expr'] = trim($parseInfo['alias']['base_expr']);
-                continue;
+                break;
 
             case 'IGNORE':
             case 'USE':
@@ -269,12 +269,12 @@ class FromProcessor extends AbstractProcessor {
             case 'OUTER':
             case 'NATURAL':
                 $parseInfo['token_count']++;
-                continue;
+                break;
 
             case 'FOR':
                 $parseInfo['token_count']++;
                 $skip_next = true;
-                continue;
+                break;
 
             case 'STRAIGHT_JOIN':
                 $parseInfo['next_join_type'] = "STRAIGHT_JOIN";
@@ -307,7 +307,7 @@ class FromProcessor extends AbstractProcessor {
                     $token_category = '';
                     $cur_hint = (count($parseInfo['hints']) - 1);
                     $parseInfo['hints'][$cur_hint]['hint_list'] = $token;
-                    continue;
+                    break;
                 }
 
                 if ($parseInfo['token_count'] === 0) {

--- a/src/PHPSQLParser/processors/InsertProcessor.php
+++ b/src/PHPSQLParser/processors/InsertProcessor.php
@@ -82,16 +82,16 @@ class InsertProcessor extends AbstractProcessor {
             switch ($upper) {
             case 'INTO':
                 $result[] = array('expr_type' => ExpressionType::RESERVED, 'base_expr' => $trim);
-                continue;
+                break;
 
             case 'INSERT':
             case 'REPLACE':
-                continue;
+                break;
 
             default:
                 if ($table === '') {
                     $table = $trim;
-                    continue;
+                    break;
                 }
 
                 if ($cols === false) {

--- a/src/PHPSQLParser/processors/SQLProcessor.php
+++ b/src/PHPSQLParser/processors/SQLProcessor.php
@@ -153,7 +153,7 @@ class SQLProcessor extends SQLChunkProcessor {
             case 'PLUGIN':
             // no separate section
                 if ($token_category === 'SHOW') {
-                    continue;
+                    break;
                 }
                 $token_category = $upper;
                 break;
@@ -165,7 +165,7 @@ class SQLProcessor extends SQLChunkProcessor {
                 }
                 // no separate section
                 if ($token_category === 'SHOW') {
-                    continue;
+                    break;
                 }
                 $token_category = $upper;
                 break;
@@ -191,10 +191,10 @@ class SQLProcessor extends SQLChunkProcessor {
             case 'DATABASE':
             case 'SCHEMA':
                 if ($prev_category === 'DROP') {
-                    continue;
+                    break;
                 }
                 if ($prev_category === 'SHOW') {
-                    continue;
+                    break;
                 }
                 $token_category = $upper;
                 break;
@@ -300,7 +300,7 @@ class SQLProcessor extends SQLChunkProcessor {
 
             case 'CREATE':
                 if ($prev_category === 'SHOW') {
-                    continue;
+                    break;
                 }
                 $token_category = $upper;
                 break;
@@ -401,7 +401,7 @@ class SQLProcessor extends SQLChunkProcessor {
 
             case 'FOR':
                 if ($prev_category === 'SHOW') {
-                    continue;
+                    break;
                 }
                 $skip_next = 1;
                 $out['OPTIONS'][] = 'FOR UPDATE'; // TODO: this could be generate problems within the position calculator

--- a/src/PHPSQLParser/processors/ShowProcessor.php
+++ b/src/PHPSQLParser/processors/ShowProcessor.php
@@ -68,7 +68,7 @@ class ShowProcessor extends AbstractProcessor {
             case 'FROM':
                 $resultList[] = array('expr_type' => ExpressionType::RESERVED, 'base_expr' => trim($token));
                 if ($prev === 'INDEX' || $prev === 'COLUMNS') {
-                    continue;
+                    break;
                 }
                 $category = $upper;
                 break;


### PR DESCRIPTION
As of PHP 7.3 using a targetting a switch with continue will throw a warning as it's deprecated. It is to be removed in PHP 8 as can be seen here https://wiki.php.net/rfc/continue_on_switch_deprecation