### PR TITLE
Move analog dependency to dev only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,11 @@
 		}
 	},
 	"require" : {
-		"php" : ">=5.3.2",
-		"analog/analog" : "^1.0.6"
+		"php" : ">=5.3.2"
 	},
 	"require-dev" : {
 		"squizlabs/php_codesniffer" : "^1.5.1",
-		"phpunit/phpunit" : "^4.0.14"
+		"phpunit/phpunit" : "^4.0.14",
+		"analog/analog" : "^1.0.6"
 	}
 }

--- a/src/PHPSQLParser/processors/HavingProcessor.php
+++ b/src/PHPSQLParser/processors/HavingProcessor.php
@@ -41,7 +41,6 @@
 
 namespace PHPSQLParser\processors;
 use PHPSQLParser\utils\ExpressionType;
-use Analog\Analog;
 
 /**
  * This class implements the processor for the HAVING statement. 

--- a/src/PHPSQLParser/processors/HavingProcessor.php
+++ b/src/PHPSQLParser/processors/HavingProcessor.php
@@ -52,13 +52,6 @@ use Analog\Analog;
  *  
  */
 class HavingProcessor extends ExpressionListProcessor {
-
-	// helper function to find an example for issue 10 on GitHub.com
-	protected function logError($sql) {
-		Analog::log("The alias clause of a colref is empty, this should not occur.", Analog::ALERT);
-		Analog::log("Please create an issue on GitHub or GoogleCode with your SQL statement.", Analog::ALERT);
-		Analog::log(print_r($sql, true), Analog::ALERT);
-	}
 	
     public function process($tokens, $select = array()) {
         $parsed = parent::process($tokens);
@@ -67,7 +60,6 @@ class HavingProcessor extends ExpressionListProcessor {
             if ($v['expr_type'] === ExpressionType::COLREF) {
                 foreach ($select as $clause) {
                     if (!isset($clause['alias'])) {
-						$this->logError($select);
                     	continue;
                     }
                     if (!$clause['alias']) {


### PR DESCRIPTION
Since issue 10 is closed, those lines should be removed, and the analog dependency as well.

Removed all uses of Analog from the library.
Keep analog only in require-dev.