### PR TITLE
Allow in-list in subtree creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 
 php:
   - 5.4
@@ -7,6 +8,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 cache:

--- a/src/PHPSQLParser/builders/SubTreeBuilder.php
+++ b/src/PHPSQLParser/builders/SubTreeBuilder.php
@@ -72,6 +72,11 @@ class SubTreeBuilder implements Builder {
         return $builder->build($parsed);
     }
 
+    protected function buildInList($parsed) {
+        $builder = new InListBuilder();
+        return $builder->build($parsed);
+    }
+
     protected function buildReserved($parsed) {
         $builder = new ReservedBuilder();
         return $builder->build($parsed);
@@ -108,6 +113,7 @@ class SubTreeBuilder implements Builder {
             $sql .= $this->buildFunction($v);
             $sql .= $this->buildOperator($v);
             $sql .= $this->buildConstant($v);
+            $sql .= $this->buildInList($v);
             $sql .= $this->buildSubQuery($v);
             $sql .= $this->buildSelectBracketExpression($v);
             $sql .= $this->buildReserved($v);

--- a/tests/cases/creator/inlistTest.php
+++ b/tests/cases/creator/inlistTest.php
@@ -53,5 +53,15 @@ class inlistTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($expected, $created, 'a subquery and in-lists');
 
     }
-}
 
+    public function testInSubtree() {
+        $sql = 'SELECT CASE WHEN 2 IN (2, 3) THEN "yes" ELSE "no" END';
+        $parser = new PHPSQLParser($sql);
+        $creator = new PHPSQLCreator($parser->parsed);
+        $created = $creator->created;
+        $expected = getExpectedValue(dirname(__FILE__), 'insubtree.sql', false);
+        $this->assertSame($expected, $created, 'a IN list in a CASE WHEN subtree');
+
+    }
+
+}

--- a/tests/expected/creator/insubtree.sql
+++ b/tests/expected/creator/insubtree.sql
@@ -1,0 +1,1 @@
+SELECT CASE WHEN 2 IN (2, 3) THEN "yes" ELSE "no" END


### PR DESCRIPTION
This PR adds a test to show-case the issue declared in #225 and fixed in #283 and #311.

The first commit actually comes from #315. It fixes Travis tests that are otherwise broken for PHP 5.4 and 5.5.

The second commit contains only the test proving that the creator is broken when managing a "in-list" inside a subtree. This commit is therefore expected to fail.

The third commit is the commit from #311 by @andrews05 fixing the issue.