### PR TITLE
Fixing Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 
 php:
   - 5.4
@@ -7,6 +8,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 cache:


### PR DESCRIPTION
Since June, Travis uses Xenial images instead of the old Trusty. PHP 5.4 and PHP 5.5 are not available on Xenial.

This PR:

- switches back to Trusty to have support for PHP 5.4 and 5.5
- adds PHP 7.3 support in Travis