### PR TITLE
Enable subquery support in WHERE expression

### DIFF
--- a/src/PHPSQLParser/builders/WhereBracketExpressionBuilder.php
+++ b/src/PHPSQLParser/builders/WhereBracketExpressionBuilder.php
@@ -53,6 +53,11 @@ use PHPSQLParser\utils\ExpressionType;
  */
 class WhereBracketExpressionBuilder implements Builder {
 
+    protected function buildSubQuery($parsed) {
+        $builder = new SubQueryBuilder();
+        return $builder->build($parsed);
+    }
+
     protected function buildColRef($parsed) {
         $builder = new ColumnReferenceBuilder();
         return $builder->build($parsed);
@@ -109,6 +114,7 @@ class WhereBracketExpressionBuilder implements Builder {
             $sql .= $this->build($v);
             $sql .= $this->buildUserVariable($v);
             $sql .= $this->buildReserved($v);
+            $sql .= $this->buildSubQuery($v);
             
             if ($len == strlen($sql)) {
                 throw new UnableToCreateSQLException('WHERE expression subtree', $k, $v, 'expr_type');

--- a/tests/cases/creator/issue316Test.php
+++ b/tests/cases/creator/issue316Test.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * issue299.php
+ *
+ * Test case for PHPSQLParser.
+ *
+ * PHP version 5
+ *
+ * LICENSE:
+ * Copyright (c) 2010-2014 Justin Swanhart and André Rothe
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author    André Rothe <andre.rothe@phosco.info>
+ * @copyright 2010-2014 Justin Swanhart and André Rothe
+ * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
+ * @version   SVN: $Id$
+ *
+ */
+namespace PHPSQLParser\Test\Creator;
+use PHPSQLParser\PHPSQLParser;
+use PHPSQLParser\PHPSQLCreator;
+
+class issue316Test extends \PHPUnit_Framework_TestCase
+{
+    public function testIssue299()
+    {
+        $parser = new PHPSQLParser();
+        $sql = 'SELECT myField WHERE (myField IN (SELECT otherField FROM otherTable))';
+        $parser->parse($sql, true);
+        $creator = new PHPSQLCreator($parser->parsed);
+        $this->assertEquals(
+            'SELECT myField WHERE (myField IN (SELECT otherField FROM otherTable))',
+            $creator->created
+        );
+    }
+}


### PR DESCRIPTION
The use of a subquery in a WHERE bracket expression was not correctly handled by the parser

See the added unit test for the actual test case

Closes #316