### PR TITLE
fix "strpos empty needle" warning

### DIFF
--- a/src/PHPSQLParser/positions/PositionCalculator.php
+++ b/src/PHPSQLParser/positions/PositionCalculator.php
@@ -127,6 +127,9 @@ class PositionCalculator {
     }
 
     protected function findPositionWithinString($sql, $value, $expr_type) {
+        if ($value === '') {
+            return false;
+        }
 
         $offset = 0;
         $ok = false;

--- a/tests/cases/parser/issue320Test.php
+++ b/tests/cases/parser/issue320Test.php
@@ -52,7 +52,7 @@ class issue320Test extends \PHPUnit_Framework_TestCase
         // but this query seems valid at least in mysql and mssql
         // so ideally PHPSQLParser would be able to parse it
         $this->setExpectedException(
-            \PHPSQLParser\exceptions\UnableToCalculatePositionException::class
+            '\PHPSQLParser\exceptions\UnableToCalculatePositionException'
         );
 
         $parser->parse($sql, true);

--- a/tests/cases/parser/issue320Test.php
+++ b/tests/cases/parser/issue320Test.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * issue320.php
+ *
+ * Test case for PHPSQLParser.
+ *
+ * PHP version 5
+ *
+ * LICENSE:
+ * Copyright (c) 2010-2014 Justin Swanhart and André Rothe
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author    André Rothe <andre.rothe@phosco.info>
+ * @copyright 2010-2014 Justin Swanhart and André Rothe
+ * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
+ * @version   SVN: $Id$
+ */
+namespace PHPSQLParser\Test\Parser;
+use PHPSQLParser\PHPSQLParser;
+use PHPSQLParser\PHPSQLCreator;
+
+class issue320Test extends \PHPUnit_Framework_TestCase
+{
+    public function test_no_warning_is_issued_when_help_table_is_used()
+    {
+        $parser = new PHPSQLParser();
+        $sql = 'SELECT * FROM help';
+
+        // there currently is an exception because `HELP` is a keyword
+        // but this query seems valid at least in mysql and mssql
+        // so ideally PHPSQLParser would be able to parse it
+        $this->setExpectedException(
+            \PHPSQLParser\exceptions\UnableToCalculatePositionException::class
+        );
+
+        $parser->parse($sql, true);
+    }
+}


### PR DESCRIPTION
fixes issue #320

a warning was issued in `PositionCalculator#findPositionWithinString`
when calling `strpos` on an empty value:

```
Warning: strpos(): Empty needle in
src/PHPSQLParser/positions/PositionCalculator.php on line 138
```

=> return `false` earlier in that case, to then throw an exception