### PR TITLE
Handle SubQuery in ref_clause

### DIFF
--- a/src/PHPSQLParser/builders/FromBuilder.php
+++ b/src/PHPSQLParser/builders/FromBuilder.php
@@ -31,12 +31,12 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * @author    André Rothe <andre.rothe@phosco.info>
  * @copyright 2010-2014 Justin Swanhart and André Rothe
  * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
  * @version   SVN: $Id$
- * 
+ *
  */
 
 namespace PHPSQLParser\builders;
@@ -48,7 +48,7 @@ use PHPSQLParser\exceptions\UnableToCreateSQLException;
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class FromBuilder implements Builder {
 

--- a/src/PHPSQLParser/builders/RefClauseBuilder.php
+++ b/src/PHPSQLParser/builders/RefClauseBuilder.php
@@ -31,24 +31,24 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * @author    André Rothe <andre.rothe@phosco.info>
  * @copyright 2010-2014 Justin Swanhart and André Rothe
  * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
  * @version   SVN: $Id$
- * 
+ *
  */
 
 namespace PHPSQLParser\builders;
 use PHPSQLParser\exceptions\UnableToCreateSQLException;
 
 /**
- * This class implements the references clause within a JOIN. 
+ * This class implements the references clause within a JOIN.
  * You can overwrite all functions to achieve another handling.
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class RefClauseBuilder implements Builder {
 
@@ -86,7 +86,12 @@ class RefClauseBuilder implements Builder {
         $builder = new ColumnListBuilder();
         return $builder->build($parsed);
     }
-    
+
+    protected function buildSubQuery($parsed) {
+        $builder = new SubQueryBuilder();
+        return $builder->build($parsed);
+    }
+
     public function build(array $parsed) {
         if ($parsed === false) {
             return '';
@@ -101,6 +106,7 @@ class RefClauseBuilder implements Builder {
             $sql .= $this->buildBracketExpression($v);
             $sql .= $this->buildInList($v);
             $sql .= $this->buildColumnList($v);
+            $sql .= $this->buildSubQuery($v);
 
             if ($len == strlen($sql)) {
                 throw new UnableToCreateSQLException('expression ref_clause', $k, $v, 'expr_type');

--- a/src/PHPSQLParser/builders/SubTreeBuilder.php
+++ b/src/PHPSQLParser/builders/SubTreeBuilder.php
@@ -31,24 +31,24 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * @author    André Rothe <andre.rothe@phosco.info>
  * @copyright 2010-2014 Justin Swanhart and André Rothe
  * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
  * @version   SVN: $Id$
- * 
+ *
  */
 
 namespace PHPSQLParser\builders;
 use PHPSQLParser\exceptions\UnableToCreateSQLException;
 
 /**
- * This class implements the builder for [sub_tree] fields. 
+ * This class implements the builder for [sub_tree] fields.
  * You can overwrite all functions to achieve another handling.
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class SubTreeBuilder implements Builder {
 
@@ -98,7 +98,7 @@ class SubTreeBuilder implements Builder {
     }
 
     public function build(array $parsed, $delim = " ") {
-        if ($parsed['sub_tree'] === '') {
+        if ($parsed['sub_tree'] === '' || $parsed['sub_tree'] === false) {
             return "";
         }
         $sql = "";

--- a/src/PHPSQLParser/builders/TableBuilder.php
+++ b/src/PHPSQLParser/builders/TableBuilder.php
@@ -31,24 +31,24 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * @author    André Rothe <andre.rothe@phosco.info>
  * @copyright 2010-2014 Justin Swanhart and André Rothe
  * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
  * @version   SVN: $Id$
- * 
+ *
  */
 
 namespace PHPSQLParser\builders;
 use PHPSQLParser\utils\ExpressionType;
 
 /**
- * This class implements the builder for the table name and join options. 
+ * This class implements the builder for the table name and join options.
  * You can overwrite all functions to achieve another handling.
  *
  * @author  André Rothe <andre.rothe@phosco.info>
  * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
- *  
+ *
  */
 class TableBuilder implements Builder {
 

--- a/src/PHPSQLParser/builders/WhereExpressionBuilder.php
+++ b/src/PHPSQLParser/builders/WhereExpressionBuilder.php
@@ -119,7 +119,7 @@ class WhereExpressionBuilder implements Builder {
             $sql .= $this->buildUserVariable($v);
             $sql .= $this->buildSubQuery($v);
             $sql .= $this->buildReserved($v);
-            
+
             if ($len == strlen($sql)) {
                 throw new UnableToCreateSQLException('WHERE expression subtree', $k, $v, 'expr_type');
             }

--- a/tests/cases/creator/leftTest.php
+++ b/tests/cases/creator/leftTest.php
@@ -31,19 +31,19 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * @author    André Rothe <andre.rothe@phosco.info>
  * @copyright 2010-2014 Justin Swanhart and André Rothe
  * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
  * @version   SVN: $Id$
- * 
+ *
  */
 namespace PHPSQLParser\Test\Creator;
 use PHPSQLParser\PHPSQLParser;
 use PHPSQLParser\PHPSQLCreator;
 
 class leftTest extends \PHPUnit_Framework_TestCase {
-	
+
     public function testLeft() {
         $sql = 'SELECT *
             FROM (t1 LEFT JOIN t2 ON t1.a=t2.a)
@@ -55,6 +55,16 @@ class leftTest extends \PHPUnit_Framework_TestCase {
         $expected = getExpectedValue(dirname(__FILE__), 'left.sql', false);
         $this->assertSame($expected, $created, 'left joins and table-expression');
 
+    }
+
+    public function testLeftIn() {
+        $sql = 'SELECT *
+            FROM (t1 LEFT JOIN t2 ON t1.a=t2.a)
+                 LEFT JOIN t3
+                 ON t3.id IN (SELECT id FROM t4)';
+        $parser = new PHPSQLParser($sql);
+        $creator = new PHPSQLCreator($parser->parsed);
+        $created = $creator->created;
     }
 }
 

--- a/tests/cases/parser/fromTest.php
+++ b/tests/cases/parser/fromTest.php
@@ -31,19 +31,19 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * @author    André Rothe <andre.rothe@phosco.info>
  * @copyright 2010-2014 Justin Swanhart and André Rothe
  * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
  * @version   SVN: $Id$
- * 
+ *
  */
 namespace PHPSQLParser\Test\Parser;
 use PHPSQLParser\PHPSQLParser;
 use PHPSQLParser\PHPSQLCreator;
 
 class FromTest extends \PHPUnit_Framework_TestCase {
-	
+
     public function testFrom1() {
         $parser = new PHPSQLParser();
 
@@ -57,9 +57,9 @@ class FromTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(1, count($p['FROM']));
         $this->assertEquals('an_alias', $p['FROM'][0]['alias']['name']);
     }
-    
+
     public function testFrom2() {
-        $sql = 'select DISTINCT 1+2   c1, 1+ 2 as 
+        $sql = 'select DISTINCT 1+2   c1, 1+ 2 as
         `c2`, sum(c2),sum(c3) as sum_c3,"Status" = CASE
                 WHEN quantity > 0 THEN \'in stock\'
                 ELSE \'out of stock\'
@@ -73,10 +73,10 @@ class FromTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('DISTINCT', $p['SELECT'][0]['base_expr']);
         $this->assertEquals('c1', $p['SELECT'][1]['alias']['name']);
         $this->assertEquals('`c2`', $p['SELECT'][2]['alias']['name']);
-        $this->assertEquals('', $p['SELECT'][3]['alias']['name'], 'no alias on sum(c2)');
+        $this->assertEquals(false, $p['SELECT'][3]['alias'], 'no alias on sum(c2)');
         $this->assertEquals('sum_c3', $p['SELECT'][4]['alias']['name']);
         $this->assertEquals('case_statement', $p['SELECT'][5]['alias']['name'], 'case statement');
-        $this->assertEquals('', $p['SELECT'][6]['alias']['name'], 'no alias on t4.c1');
+        $this->assertEquals(false, $p['SELECT'][6]['alias'], 'no alias on t4.c1');
         $this->assertEquals('subquery', $p['SELECT'][7]['alias']['name']);
     }
 }

--- a/tests/cases/parser/issue322Test.php
+++ b/tests/cases/parser/issue322Test.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * issue322.php
+ *
+ * Test case for PHPSQLParser.
+ *
+ * PHP version 5
+ *
+ * LICENSE:
+ * Copyright (c) 2010-2014 Justin Swanhart and André Rothe
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author    André Rothe <andre.rothe@phosco.info>
+ * @copyright 2010-2014 Justin Swanhart and André Rothe
+ * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
+ * @version   SVN: $Id$
+ *
+ */
+namespace PHPSQLParser\Test\Parser;
+use PHPSQLParser\PHPSQLParser;
+use PHPSQLParser\PHPSQLCreator;
+
+class issue322Test extends \PHPUnit_Framework_TestCase
+{
+	public function testIssue322()
+	{
+        $sql = "SELECT IF(createdAt >= CURRENT_DATE(), '1', '0') FROM f_another_table WHERE id in(SELECT id FROM f_table WHERE createdAt > NOW())";
+		$parser = new PHPSQLParser();
+		$parsed = $parser->parse($sql, true);
+		$creator = new PHPSQLCreator();
+		$sql = $creator->create($parsed);
+		echo $sql;
+    }
+}
+


### PR DESCRIPTION
Fixes cases like this:

```sql
SELECT * FROM (t1 LEFT JOIN t2 ON t1.a=t2.a) LEFT JOIN t3 ON t3.id IN (SELECT id FROM t4)
```