### PR TITLE
Revert "UNION scan of remainder looks too deep for parentheses"

### DIFF
--- a/src/PHPSQLParser/processors/UnionProcessor.php
+++ b/src/PHPSQLParser/processors/UnionProcessor.php
@@ -117,14 +117,12 @@ class UnionProcessor extends AbstractProcessor {
     protected function splitUnionRemainder($queries, $unionType, $outputArray)
     {
         $finalQuery = [];
-        $firstTime = true;
-        $finalQueryFound = false;
-        //If this token contains a matching pair of brackets at the start and end, use it as the final query
-        foreach ($outputArray as $key => $token) {
-            $tokenAsArray = str_split(trim($token));
-            $keyCount = max(array_keys($tokenAsArray));
 
-            if ($tokenAsArray[0] == '(' && $tokenAsArray[$keyCount] == ')' && $firstTime) {
+        //If this token contains a matching pair of brackets at the start and end, use it as the final query
+        $finalQueryFound = false;
+        if (count($outputArray) === 1) {
+            $tokenAsArray = str_split(trim($outputArray[0]));
+            if ($tokenAsArray[0] == '(' && $tokenAsArray[count($tokenAsArray)-1] == ')') {
                 $queries[$unionType][] = $outputArray;
                 $finalQueryFound = true;
             }
@@ -138,10 +136,6 @@ class UnionProcessor extends AbstractProcessor {
                     $finalQuery[] = $token;
                     unset($outputArray[$key]);
                 }
-            }
-
-            if ($firstTime && !empty($token)) {
-                $firstTime = false;
             }
         }
 


### PR DESCRIPTION
Reverts greenlion/PHP-SQL-Parser#293