### PR TITLE
Add ignore comment option

### DIFF
--- a/src/PHPSQLParser/Options.php
+++ b/src/PHPSQLParser/Options.php
@@ -29,6 +29,12 @@ final class Options
      */
     const ANSI_QUOTES = 'ansi_quotes';
 
+
+    /**
+     * @const string
+     */
+    const IGNORE_COMMENT = 'ignore_comment';
+
     /**
      * Options constructor.
      *
@@ -53,5 +59,13 @@ final class Options
     public function getANSIQuotes()
     {
         return (isset($this->options[self::ANSI_QUOTES]) && $this->options[self::ANSI_QUOTES]);
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIgnoreComment()
+    {
+        return (isset($this->options[self::IGNORE_COMMENT]) && $this->options[self::IGNORE_COMMENT]);
     }
 }

--- a/src/PHPSQLParser/processors/ExpressionListProcessor.php
+++ b/src/PHPSQLParser/processors/ExpressionListProcessor.php
@@ -62,7 +62,10 @@ class ExpressionListProcessor extends AbstractProcessor {
 
 
             if ($this->isCommentToken($v)) {
-                $resultList[] = parent::processComment($v);
+                if(!$this->options->getIgnoreComment()) {
+                    $resultList[] = parent::processComment($v);
+                }
+
                 continue;
             }
 

--- a/src/PHPSQLParser/processors/FromProcessor.php
+++ b/src/PHPSQLParser/processors/FromProcessor.php
@@ -170,7 +170,10 @@ class FromProcessor extends AbstractProcessor {
             }
 
             if ($this->isCommentToken($token)) {
-                $expr[] = parent::processComment($token);
+                if(!$this->options->getIgnoreComment()) {
+                    $expr[] = parent::processComment($token);
+                }
+
                 continue;
             }
 

--- a/src/PHPSQLParser/processors/InsertProcessor.php
+++ b/src/PHPSQLParser/processors/InsertProcessor.php
@@ -136,8 +136,11 @@ class InsertProcessor extends AbstractProcessor {
             }
             foreach ($token as &$value) {
                 if ($this->isCommentToken($value)) {
-                     $comments[] = parent::processComment($value);
-                     $value = '';
+                    if(!$this->options->getIgnoreComment()) {
+                        $comments[] = parent::processComment($value);
+                    }
+
+                    $value = '';
                 }
             }
         }

--- a/src/PHPSQLParser/processors/LimitProcessor.php
+++ b/src/PHPSQLParser/processors/LimitProcessor.php
@@ -61,8 +61,11 @@ class LimitProcessor extends AbstractProcessor {
         
         foreach ($tokens as &$token) {
             if ($this->isCommentToken($token)) {
-                 $comments[] = parent::processComment($token);
-                 $token = '';
+                if(!$this->options->getIgnoreComment()) {
+                    $comments[] = parent::processComment($token);
+                }
+
+                $token = '';
             }
         }
         

--- a/src/PHPSQLParser/processors/OrderByProcessor.php
+++ b/src/PHPSQLParser/processors/OrderByProcessor.php
@@ -127,7 +127,10 @@ class OrderByProcessor extends AbstractProcessor {
 
             default:
                 if ($this->isCommentToken($token)) {
-                    $out[] = parent::processComment($token);
+                    if(!$this->options->getIgnoreComment()) {
+                        $out[] = parent::processComment($token);
+                    }
+
                     break;
                 }
 

--- a/src/PHPSQLParser/processors/SelectProcessor.php
+++ b/src/PHPSQLParser/processors/SelectProcessor.php
@@ -33,11 +33,11 @@
 namespace PHPSQLParser\processors;
 
 /**
- * 
+ *
  * This class processes the SELECT statements.
- * 
+ *
  * @author arothe
- * 
+ *
  */
 class SelectProcessor extends SelectExpressionProcessor {
 
@@ -51,7 +51,9 @@ class SelectProcessor extends SelectExpressionProcessor {
                 $expressionList[] = $expression;
                 $expression = "";
             } else if ($this->isCommentToken($token)) {
-                $expressionList[] = parent::processComment($token);
+                if(!$this->options->getIgnoreComment()) {
+                    $expressionList[] = parent::processComment($token);
+                }
             } else {
                 switch (strtoupper($token)) {
 

--- a/src/PHPSQLParser/processors/ValuesProcessor.php
+++ b/src/PHPSQLParser/processors/ValuesProcessor.php
@@ -69,7 +69,10 @@ class ValuesProcessor extends AbstractProcessor {
 
         foreach ($tokens['VALUES'] as $k => $v) {
 	        if ($this->isCommentToken($v)) {
-		        $parsed[] = parent::processComment($v);
+	            if(!$this->options->getIgnoreComment()) {
+                    $parsed[] = parent::processComment($v);
+                }
+
 		        continue;
 	        }
 

--- a/tests/cases/parser/ignoreCommentTest.php
+++ b/tests/cases/parser/ignoreCommentTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace PHPSQLParser\Test\Parser;
+
+use PHPSQLParser\PHPSQLParser;
+
+class IgnoreCommentsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testComments1()
+    {
+        $sqlWithComment = 'SELECT a, -- inline comment in SELECT section
+                        b 
+                    FROM test';
+        $sqlWithoutComment = 'SELECT a,
+                        b 
+                    FROM test';
+
+        $this->commonAssert($sqlWithComment, $sqlWithoutComment, 'inline comment in SELECT section');
+    }
+
+    public function testComments2()
+    {
+        $sqlWithComment = 'SELECT a, /* 
+                            multi line 
+                            comment
+                        */
+                        b 
+                    FROM test';
+        $sqlWithoutComment = 'SELECT a,
+                        b 
+                    FROM test';
+
+        $this->commonAssert($sqlWithComment, $sqlWithoutComment, 'multi line comment');
+    }
+
+    public function testComments3()
+    {
+        $sqlWithComment = 'SELECT a
+                    FROM test -- inline comment in FROM section';
+        $sqlWithoutComment = 'SELECT a
+                    FROM test';
+
+        $this->commonAssert($sqlWithComment, $sqlWithoutComment, 'inline comment in FROM section');
+    }
+
+    public function testComments4()
+    {
+        $sqlWithComment = 'SELECT a
+                    FROM test
+                    WHERE id = 3 -- inline comment in WHERE section
+                    AND b > 4';
+        $sqlWithoutComment = 'SELECT a
+                    FROM test
+                    WHERE id = 3
+                    AND b > 4';
+
+        $this->commonAssert($sqlWithComment, $sqlWithoutComment, 'inline comment in WHERE section');
+    }
+
+    public function testComments5()
+    {
+        $sqlWithComment = 'SELECT a
+                    FROM test
+                    LIMIT -- inline comment in LIMIT section
+                     10';
+        $sqlWithoutComment = 'SELECT a
+                    FROM test
+                    LIMIT
+                     10';
+
+        $this->commonAssert($sqlWithComment, $sqlWithoutComment, 'inline comment in LIMIT section');
+    }
+
+    public function testComments6()
+    {
+        $sqlWithComment = 'SELECT a
+                    FROM test
+                    ORDER BY -- inline comment in ORDER BY section
+                     a DESC';
+        $sqlWithoutComment = 'SELECT a
+                    FROM test
+                    ORDER BY
+                     a DESC';
+
+        $this->commonAssert($sqlWithComment, $sqlWithoutComment, 'inline comment in ORDER BY section');
+    }
+
+    public function testComments7()
+    {
+        $sqlWithComment = 'INSERT INTO a (id) -- inline comment in INSERT section
+                    VALUES (1)';
+        $sqlWithoutComment = 'INSERT INTO a (id)
+                    VALUES (1)';
+
+        $this->commonAssert($sqlWithComment, $sqlWithoutComment, 'inline comment in INSERT section');
+    }
+
+    public function testComments8()
+    {
+        $sqlWithComment = 'INSERT INTO a (id) 
+                    VALUES (1) -- inline comment in VALUES section';
+        $sqlWithoutComment = 'INSERT INTO a (id) 
+                    VALUES (1)';
+
+        $this->commonAssert($sqlWithComment, $sqlWithoutComment, 'inline comment in VALUES section');
+    }
+
+    public function testComments9()
+    {
+        $sqlWithComment = 'INSERT INTO a (id) -- inline comment in INSERT section;
+                    SELECT id -- inline comment in SELECT section
+                    FROM x';
+        $sqlWithoutComment = 'INSERT INTO a (id)
+                    SELECT id
+                    FROM x';
+        $this->commonAssert($sqlWithComment, $sqlWithoutComment, 'inline comment in SELECT section');
+    }
+
+    private function commonAssert($sqlWithComment, $sqlWithoutComment, $assertMessage)
+    {
+        $withComment = (new PHPSQLParser($sqlWithComment, false, ['ignore_comment' => true]))->parsed;
+        $withoutComment = (new PHPSQLParser($sqlWithoutComment, false, ['ignore_comment' => false]))->parsed;
+        $this->assertEquals($withComment, $withoutComment, $assertMessage);
+    }
+}
+
+?>


### PR DESCRIPTION
Hello. Nice to meet you. 
The Parser is a good one, but I'm having a bit of trouble with it. You can parse SQL with comments, but there is an error when generating SQL from a parsed SQL containing comments.
The generated SQL is a single row, so generating it with comments can be tricky.
So I added a new parse option called ignore_comment. If you set it to true, the comments will be ignored and parsed.
Please check the change by all means.