### PR TITLE
Fix PHP 8 deprecation notice

### DIFF
--- a/src/PHPSQLParser/utils/ExpressionToken.php
+++ b/src/PHPSQLParser/utils/ExpressionToken.php
@@ -56,7 +56,7 @@ class ExpressionToken {
         return $idx !== false ? $this->token[$idx] : $this->token;
     }
 
-    public function setNoQuotes($token, $qchars = null, Options $options) {
+    public function setNoQuotes($token, $qchars, Options $options) {
         $this->noQuotes = ($token === null) ? null : $this->revokeQuotation($token, $options);
     }
 


### PR DESCRIPTION
When using the project with PHP 8, you get the following notice:
```
PHP Deprecated:  Required parameter $options follows optional parameter $qchars in vendor\greenlion\php-sql-parser\src\PHPSQLParser\utils\ExpressionToken.php on line 59
```