### PR TITLE
#347 fixes deprecation warning with PHP 8.1

### DIFF
--- a/src/PHPSQLParser/processors/SQLProcessor.php
+++ b/src/PHPSQLParser/processors/SQLProcessor.php
@@ -59,7 +59,7 @@ class SQLProcessor extends SQLChunkProcessor {
         $prev_category = "";
         $token_category = "";
         $skip_next = 0;
-        $out = false;
+        $out = array();
 
 	// $tokens may come as a numeric indexed array starting with an index greater than 0 (or as a boolean)
 	$tokenCount = count($tokens);
@@ -507,6 +507,10 @@ class SQLProcessor extends SQLChunkProcessor {
             }
 
             $prev_category = $token_category;
+        }
+
+        if (count($out) === 0) {
+            return false;
         }
 
         return parent::process($out);


### PR DESCRIPTION
I haven't been able to run test suite on this because I don't have PHP 5.x installed... ha.

The issue raised in #347 is because `$out` was set to `false` and PHP now issues a deprecation notice if you try to implicitly convert a bool to an array. To fix this, I changed `$out` to being initialized as an empty array, and then at the end of the method, returned `false` to preserve BC if the array was still empty.