### PR TITLE
Added badly documented data type alias

### DIFF
--- a/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php
+++ b/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php
@@ -123,6 +123,7 @@ class ColumnDefinitionProcessor extends AbstractProcessor {
                 break 2;
 
             case 'VARCHAR':
+            case 'VARCHARACTER': // Alias for VARCHAR
                 $expr[] = array('expr_type' => ExpressionType::DATA_TYPE, 'base_expr' => $trim, 'length' => false);
                 $prevCategory = 'TEXT';
                 $currCategory = 'SINGLE_PARAM_PARENTHESIS';
@@ -155,10 +156,15 @@ class ColumnDefinitionProcessor extends AbstractProcessor {
             case 'TINYBIT':
             case 'TINYINT':
             case 'SMALLINT':
+            case 'INT2':        // Alias of SMALLINT
             case 'MEDIUMINT':
+            case 'INT3':        // Alias of MEDIUMINT
+            case 'MIDDLEINT':   // Alias of MEDIUMINT
             case 'INT':
             case 'INTEGER':
+            case 'INT4':        // Alias of INT
             case 'BIGINT':
+            case 'INT8':        // Alias of BIGINT
             case 'BOOL':
             case 'BOOLEAN':
                 $expr[] = array('expr_type' => ExpressionType::DATA_TYPE, 'base_expr' => $trim, 'unsigned' => false,
@@ -181,6 +187,7 @@ class ColumnDefinitionProcessor extends AbstractProcessor {
                 continue 2;
 
             case 'CHAR':
+            case 'CHARACTER':   // Alias for CHAR
                 $expr[] = array('expr_type' => ExpressionType::DATA_TYPE, 'base_expr' => $trim, 'length' => false);
                 $currCategory = 'SINGLE_PARAM_PARENTHESIS';
                 $prevCategory = 'TEXT';
@@ -188,7 +195,9 @@ class ColumnDefinitionProcessor extends AbstractProcessor {
 
             case 'REAL':
             case 'DOUBLE':
+            case 'FLOAT8':      // Alias for DOUBLE
             case 'FLOAT':
+            case 'FLOAT4':      // Alias for FLOAT
                 $expr[] = array('expr_type' => ExpressionType::DATA_TYPE, 'base_expr' => $trim, 'unsigned' => false,
                                 'zerofill' => false);
                 $currCategory = 'TWO_PARAM_PARENTHESIS';

--- a/tests/cases/parser/issue355Test.php
+++ b/tests/cases/parser/issue355Test.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PHPSQLParser\Test\Parser;
+use PHPSQLParser\PHPSQLParser;
+use PHPSQLParser\PHPSQLCreator;
+
+class issue355Test extends \PHPUnit\Framework\TestCase
+{
+	public function testIssue322()
+	{
+        $sql = "
+            CREATE TABLE `test_alias` (
+              `a` INTEGER,
+              `b` CHARACTER(10),
+              `c` VARCHARACTER(10),
+              `d` INT2,
+              `e` INT3,
+              `f` INT4,
+              `g` INT8,
+              `h` FLOAT4,
+              `i` FLOAT8,
+              `j` MIDDLEINT
+            );
+        ";
+		$parser = new PHPSQLParser();
+        $parser->parse($sql, true);
+        // We expect to see 10 parsed columns
+        $this->assertEquals(
+            10,
+            count($parser->parsed['TABLE']['create-def']['sub_tree'])
+        );
+
+    }
+}
+


### PR DESCRIPTION
  # Problem

#355 
  
  When parsing the following query:
  
  ```sql
  CREATE TABLE `a` (
      `b` CHARACTER(20)
  );
  ```
  
  I received the following warning and the parsed result did not contain column `b`:
  
  ```
  PHP Notice:  Undefined variable: prevCategory in /vendor/greenlion/php-sql-parser/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php on line 370
  ```
  
  I dug into it a bit more and I realised the code didn't support some of the less well documented data types (or rather data type aliases).
  
  # Understanding aliases
  
  Creating a table using these aliases is acceptable and will automatically map them to the more familiar types.
  
  ```sql
  CREATE TABLE `test_alias` (
      `a` INTEGER,
      `b` CHARACTER(10),
      `c` VARCHARACTER(10),
      `d` INT2,
      `e` INT3,
      `f` INT4,
      `g` INT8,
      `h` FLOAT4,
      `i` FLOAT8,
      `j` MIDDLEINT
  );
  
  SHOW CREATE TABLE test_alias \G
  *************************** 1. row ***************************
         Table: test
  Create Table: CREATE TABLE `test_alias` (
    `a` int DEFAULT NULL,
    `b` char(10) DEFAULT NULL,
    `c` varchar(10) DEFAULT NULL,
    `d` smallint DEFAULT NULL,
    `e` mediumint DEFAULT NULL,
    `f` int DEFAULT NULL,
    `g` bigint DEFAULT NULL,
    `h` float DEFAULT NULL,
    `i` double DEFAULT NULL,
    `j` mediumint DEFAULT NULL
  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
  ```
  
  # Real world impact
  
  While these types are not commonly used, there are cases where you will end up parsing a query using them. One example is the `performance_schema` which seems to use some of the aliases in the `DIGEST_TEXT` fields.
  
  So if I create this table:
  
  ```sql
  CREATE TABLE `test_digest` (
      `a` INT,
      `b` CHAR(10),
      `c` VARCHAR(10),
      `d` BIGINT,
      `e` FLOAT,
      `f` DOUBLE,
      `g` MEDIUMINT
  );
  ```
  
  and then I ask the `performance_schema` about this query, it will return this:
  
  ```sql
  SELECT DIGEST_TEXT
  FROM performance_schema.events_statements_summary_by_digest
  WHERE DIGEST_TEXT LIKE "CREATE TABLE `test_digest` %" \G
  *************************** 1. row ***************************
  DIGEST_TEXT: CREATE TABLE `test_digest` (
      `a` INTEGER ,
      `b` CHARACTER (?) ,
      `c` VARCHARACTER (?) ,
      `d` INT8 ,
      `e` FLOAT4 ,
      `f` FLOAT8 ,
      `g` MIDDLEINT
  )
  ```
  
  # Solution
  
Add the missing aliases (or at least the ones I can find based on examples and trawling through the [MySQL Keywords List](https://dev.mysql.com/doc/refman/8.0/en/keywords.html))

## Added Aliases
```
CHARACTER - CHAR
VARCHARACTER - VARCHAR
INT2 - SMALLINT
INT3 - MEDIUMINT
MIDDLEINT - MEDIUMINT
INT4 - INT
INT8 - BIGINT
FLOAT4 - FLOAT
FLOAT8 - DOUBLE
```