### PR TITLE
UnableToCalculatePositionException if a function is used inside JOIN condition

### DIFF
--- a/src/PHPSQLParser/positions/PositionCalculator.php
+++ b/src/PHPSQLParser/positions/PositionCalculator.php
@@ -90,7 +90,8 @@ class PositionCalculator {
                                                 ExpressionType::SUBPARTITION_HASH, ExpressionType::SUBPARTITION_COUNT,
                                                 ExpressionType::CHARSET, ExpressionType::ENGINE, ExpressionType::QUERY,
                                                 ExpressionType::INDEX_ALGORITHM, ExpressionType::INDEX_LOCK,
-    											ExpressionType::SUBQUERY_FACTORING, ExpressionType::CUSTOM_FUNCTION
+    											ExpressionType::SUBQUERY_FACTORING, ExpressionType::CUSTOM_FUNCTION,
+                                                ExpressionType::SIMPLE_FUNCTION
     );
 
     /**

--- a/tests/cases/creator/issue319Test.php
+++ b/tests/cases/creator/issue319Test.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PHPSQLParser\Test\Creator;
+use PHPSQLParser\PHPSQLParser;
+use PHPSQLParser\PHPSQLCreator;
+
+class issue319Test extends \PHPUnit\Framework\TestCase
+{
+    public function testIssue319()
+    {
+        $sql = 'SELECT start_date FROM users INNER JOIN vacation ON DATE(start_date) <= DATE(end_date)';
+
+        $parser = new PHPSQLParser();
+        $creator = new PHPSQLCreator();
+
+        $parser->parse($sql, true);
+
+        $this->assertEquals($sql, $creator->create($parser->parsed));
+    }
+}


### PR DESCRIPTION
With the following code:

```php
$query = 'SELECT start_date FROM users INNER JOIN vacation ON DATE(start_date) <= DATE(end_date)';
$parser = new \PHPSQLParser\PHPSQLParser($query, true);
```

an exception is thrown:

```
# Error        PHPSQLParser\exceptions\UnableToCalculatePositionException
# File      External/greenlion/php-sql-parser/src/PHPSQLParser/positions/PositionCalculator.php
# Line 243
# Trace
# File       Function        Line
# External/greenlion/php-sql-parser/src/PHPSQLParser/positions/PositionCalculator.php   lookForBaseExpression   259
# External/greenlion/php-sql-parser/src/PHPSQLParser/positions/PositionCalculator.php   lookForBaseExpression   259
# External/greenlion/php-sql-parser/src/PHPSQLParser/positions/PositionCalculator.php   lookForBaseExpression   125
# External/greenlion/php-sql-parser/src/PHPSQLParser/PHPSQLParser.php   setPositionsWithinSQL   100
# External/greenlion/php-sql-parser/src/PHPSQLParser/PHPSQLParser.php   parse   75

# [2020-04-01 07:02:15] - Exception     cannot calculate position of vacation ON DATE(start_date) <= DATE(end_date) within )
```