### PR TITLE
Add handling index hints in FROM and JOIN

### DIFF
--- a/src/PHPSQLParser/processors/FromProcessor.php
+++ b/src/PHPSQLParser/processors/FromProcessor.php
@@ -190,6 +190,11 @@ class FromProcessor extends AbstractProcessor {
                 if ($token_category === 'LEFT' || $token_category === 'RIGHT' || $token_category === 'NATURAL') {
                     $token_category = '';
                     $parseInfo['next_join_type'] = strtoupper(trim($prevToken)); // it seems to be a join
+                } elseif ($token_category === 'IDX_HINT') {
+                    $parseInfo['expression'] .= $token;
+                    if ($parseInfo['ref_type'] !== false) { // all after ON / USING
+                        $parseInfo['ref_expr'] .= $token;
+                    }
                 }
                 break;
 
@@ -276,6 +281,12 @@ class FromProcessor extends AbstractProcessor {
                 break;
 
             case 'FOR':
+                if ($token_category === 'IDX_HINT') {
+                    $cur_hint = (count($parseInfo['hints']) - 1);
+                    $parseInfo['hints'][$cur_hint]['hint_type'] .= " " . $upper;
+                    continue 2;
+                }
+
                 $parseInfo['token_count']++;
                 $skip_next = true;
                 break;
@@ -295,6 +306,12 @@ class FromProcessor extends AbstractProcessor {
                 $parseInfo['next_join_type'] = 'CROSS';
 
             case 'JOIN':
+                if ($token_category === 'IDX_HINT') {
+                    $cur_hint = (count($parseInfo['hints']) - 1);
+                    $parseInfo['hints'][$cur_hint]['hint_type'] .= " " . $upper;
+                    continue 2;
+                }
+
                 if ($parseInfo['subquery']) {
                     $parseInfo['sub_tree'] = $this->parse($this->removeParenthesisFromStart($parseInfo['subquery']));
                     $parseInfo['expression'] = $parseInfo['subquery'];
@@ -303,6 +320,13 @@ class FromProcessor extends AbstractProcessor {
                 $expr[] = $this->processFromExpression($parseInfo);
                 $parseInfo = $this->initParseInfo($parseInfo);
                 break;
+
+            case 'GROUP BY':
+                if ($token_category === 'IDX_HINT') {
+                    $cur_hint = (count($parseInfo['hints']) - 1);
+                    $parseInfo['hints'][$cur_hint]['hint_type'] .= " " . $upper;
+                    continue 2;
+                }
 
             default:
                 // TODO: enhance it, so we can have base_expr to calculate the position of the keywords

--- a/src/PHPSQLParser/processors/SQLProcessor.php
+++ b/src/PHPSQLParser/processors/SQLProcessor.php
@@ -400,7 +400,7 @@ class SQLProcessor extends SQLChunkProcessor {
                 break;
 
             case 'FOR':
-                if ($prev_category === 'SHOW') {
+                if ($prev_category === 'SHOW' || $token_category === 'FROM') {
                     break;
                 }
                 $skip_next = 1;

--- a/tests/cases/creator/issue125Test.php
+++ b/tests/cases/creator/issue125Test.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace PHPSQLParser\Test\Creator;
+use PHPSQLParser\PHPSQLParser;
+use PHPSQLParser\PHPSQLCreator;
+
+class issue125Test extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider indexHintsDataProvider
+     * @param string $hintType
+     */
+    public function testIssue125FromIndexHint($hintType)
+    {
+        $sql = sprintf(
+            'SELECT start_date FROM users %s INDEX (vacation_idx, users_idx) INNER JOIN vacation ON start_date = end_date',
+            $hintType
+        );
+
+        $parser = new PHPSQLParser();
+        $creator = new PHPSQLCreator();
+
+        $parser->parse($sql, true);
+
+        $this->assertEquals($sql, $creator->create($parser->parsed));
+    }
+
+    /**
+     * @dataProvider indexHintsDataProvider
+     * @param string $hintType
+     */
+    public function testIssue125JoinIndexHint($hintType)
+    {
+        $sql = sprintf(
+            'SELECT start_date FROM users %s INDEX FOR JOIN (vacation_idx, users_idx) INNER JOIN vacation ON start_date = end_date',
+            $hintType
+        );
+
+        $parser = new PHPSQLParser();
+        $creator = new PHPSQLCreator();
+
+        $parser->parse($sql, true);
+
+        $this->assertEquals($sql, $creator->create($parser->parsed));
+    }
+
+    public function indexHintsDataProvider()
+    {
+        return array(
+            array('USE'),
+            array('FORCE'),
+            array('IGNORE')
+        );
+    }
+}


### PR DESCRIPTION
Queries:
```sql
SELECT start_date FROM users USE INDEX FOR JOIN (vacation_idx, users_idx) INNER JOIN vacation ON start_date = end_date;
SELECT start_date FROM users FORCE INDEX FOR JOIN (vacation_idx, users_idx) INNER JOIN vacation ON start_date = end_date;
```

Cannot be parsed because of exception:
```
cannot calculate position of users FORCE INDEX   (vacation_idx, users_idx) within  users FORCE INDEX FOR JOIN (vacation_idx, users_idx) INNER JOIN vacation ON start_date = end_date
```

This PR adds support for parsing joins index hints.
It doesn't fix index hints for `GROUP BY` and `ORDER BY`!