### PR TITLE
Adds support for missing spaces near parentheses

### DIFF
--- a/src/PHPSQLParser/positions/PositionCalculator.php
+++ b/src/PHPSQLParser/positions/PositionCalculator.php
@@ -148,8 +148,9 @@ class PositionCalculator {
             }
 
             // if we have a quoted string, we every character is allowed after it
-            // see issue 137
-            $quoted = ($sql[$pos + strlen($value) - 1] === '`');
+            // see issues 137 and 361
+            $quotedBefore = in_array($sql[$pos], array('`', '('), true);
+            $quotedAfter = in_array($sql[$pos + strlen($value) - 1], array('`', ')'), true);
             $after = "";
             if (isset($sql[$pos + strlen($value)])) {
                 $after = $sql[$pos + strlen($value)];
@@ -178,10 +179,11 @@ class PositionCalculator {
             // in all other cases we accept
             // whitespace, comma, operators, parenthesis and end_of_string
 
-            $ok = ($before === "" || in_array($before, self::$allowedOnOther, true));
+            $ok = ($before === "" || in_array($before, self::$allowedOnOther, true)
+                || ($quotedBefore && (strtolower($before) >= 'a' && strtolower($before) <= 'z')));
             $ok = $ok
                 && ($after === "" || in_array($after, self::$allowedOnOther, true)
-                    || ($quoted && (strtolower($after) >= 'a' && strtolower($after) <= 'z')));
+                    || ($quotedAfter && (strtolower($after) >= 'a' && strtolower($after) <= 'z')));
 
             if ($ok) {
                 break;

--- a/tests/cases/creator/issue361Test.php
+++ b/tests/cases/creator/issue361Test.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PHPSQLParser\Test\Creator;
+use PHPSQLParser\PHPSQLParser;
+use PHPSQLParser\PHPSQLCreator;
+
+class issue361Test extends \PHPUnit\Framework\TestCase
+{
+    public function testIssue361()
+    {
+        $sql = 'SELECT IF(status = 1,1,0)FROM users INNER JOIN names ON(users.name = names.name)WHERE(users.id IN(123, 456))AND names.name = "adam"';
+        $createdSql = 'SELECT IF(status = 1,1,0) FROM users INNER JOIN names ON (users.name = names.name) '
+            . 'WHERE (users.id IN (123, 456)) AND names.name = "adam"';
+
+        $parser = new PHPSQLParser();
+        $creator = new PHPSQLCreator();
+
+        $parser->parse($sql, true);
+
+        $this->assertEquals($createdSql, $creator->create($parser->parsed));
+    }
+}


### PR DESCRIPTION
The following query was producing `UnableToCalculatePositionException`, although it is a valid sql query:

```sql
SELECT IF(status = 1,1,0)FROM users INNER JOIN names ON(users.name = names.name)WHERE(users.id IN(123, 456))AND names.name = "adam"
```