### PR TITLE
Add Additional Builders for CREATE statements

### DIFF
--- a/src/PHPSQLParser/builders/ColumnTypeBuilder.php
+++ b/src/PHPSQLParser/builders/ColumnTypeBuilder.php
@@ -80,6 +80,13 @@ class ColumnTypeBuilder implements Builder {
         return $parsed['base_expr'];
     }
 
+    protected function buildCollation($parsed) {
+        if ($parsed['expr_type'] !== ExpressionType::COLLATE) {
+            return "";
+        }
+        return $parsed['base_expr'];
+    }
+
     public function build(array $parsed) {
         if ($parsed['expr_type'] !== ExpressionType::COLUMN_TYPE) {
             return "";
@@ -92,6 +99,7 @@ class ColumnTypeBuilder implements Builder {
             $sql .= $this->buildReserved($v);
             $sql .= $this->buildDefaultValue($v);
             $sql .= $this->buildCharacterSet($v);
+            $sql .= $this->buildCollation($v);
 
             if ($len == strlen($sql)) {
                 throw new UnableToCreateSQLException('CREATE TABLE column-type subtree', $k, $v, 'expr_type');

--- a/src/PHPSQLParser/builders/ColumnTypeBuilder.php
+++ b/src/PHPSQLParser/builders/ColumnTypeBuilder.php
@@ -87,6 +87,13 @@ class ColumnTypeBuilder implements Builder {
         return $parsed['base_expr'];
     }
 
+    protected function buildComment($parsed) {
+        if ($parsed['expr_type'] !== ExpressionType::COMMENT) {
+            return "";
+        }
+        return $parsed['base_expr'];
+    }
+
     public function build(array $parsed) {
         if ($parsed['expr_type'] !== ExpressionType::COLUMN_TYPE) {
             return "";
@@ -100,6 +107,7 @@ class ColumnTypeBuilder implements Builder {
             $sql .= $this->buildDefaultValue($v);
             $sql .= $this->buildCharacterSet($v);
             $sql .= $this->buildCollation($v);
+            $sql .= $this->buildComment($v);
 
             if ($len == strlen($sql)) {
                 throw new UnableToCreateSQLException('CREATE TABLE column-type subtree', $k, $v, 'expr_type');

--- a/src/PHPSQLParser/builders/FulltextIndexBuilder.php
+++ b/src/PHPSQLParser/builders/FulltextIndexBuilder.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * IndexKeyBuilder.php
+ *
+ * Builds index key part of a CREATE TABLE statement.
+ *
+ * PHP version 5
+ *
+ * LICENSE:
+ * Copyright (c) 2010-2014 Justin Swanhart and André Rothe
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * @author    André Rothe <andre.rothe@phosco.info>
+ * @copyright 2010-2014 Justin Swanhart and André Rothe
+ * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
+ * @version   SVN: $Id$
+ * 
+ */
+
+namespace PHPSQLParser\builders;
+use PHPSQLParser\exceptions\UnableToCreateSQLException;
+use PHPSQLParser\utils\ExpressionType;
+
+/**
+ * This class implements the builder for the index key part of a CREATE TABLE statement. 
+ * You can overwrite all functions to achieve another handling.
+ *
+ * @author  André Rothe <andre.rothe@phosco.info>
+ * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
+ *  
+ */
+class FulltextIndexBuilder implements Builder {
+
+    protected function buildReserved($parsed) {
+        $builder = new ReservedBuilder();
+        return $builder->build($parsed);
+    }
+
+    protected function buildConstant($parsed) {
+        $builder = new ConstantBuilder();
+        return $builder->build($parsed);
+    }
+    
+    protected function buildIndexKey($parsed) {
+        if ($parsed['expr_type'] !== ExpressionType::INDEX) {
+            return "";
+        }
+        return $parsed['base_expr'];
+    }
+    
+    protected function buildColumnList($parsed) {
+        $builder = new ColumnListBuilder();
+        return $builder->build($parsed);
+    }
+    
+    public function build(array $parsed) {
+        if ($parsed['expr_type'] !== ExpressionType::FULLTEXT_IDX) {
+            return "";
+        }
+        $sql = "";
+        foreach ($parsed['sub_tree'] as $k => $v) {
+            $len = strlen($sql);
+            $sql .= $this->buildReserved($v);
+            $sql .= $this->buildColumnList($v);
+            $sql .= $this->buildConstant($v);
+            $sql .= $this->buildIndexKey($v);
+
+            if ($len == strlen($sql)) {
+                throw new UnableToCreateSQLException('CREATE TABLE fulltext-index key subtree', $k, $v, 'expr_type');
+            }
+
+            $sql .= " ";
+        }
+        return substr($sql, 0, -1);
+    }
+}
+?>

--- a/src/PHPSQLParser/builders/TableBracketExpressionBuilder.php
+++ b/src/PHPSQLParser/builders/TableBracketExpressionBuilder.php
@@ -84,6 +84,16 @@ class TableBracketExpressionBuilder implements Builder {
         return $builder->build($parsed);
     }
     
+    protected function buildUniqueIndex($parsed) {
+        $builder = new UniqueIndexBuilder();
+        return $builder->build($parsed);
+    }
+    
+    protected function buildFulltextIndex($parsed) {
+        $builder = new FulltextIndexBuilder();
+        return $builder->build($parsed);
+    }
+    
     public function build(array $parsed) {
         if ($parsed['expr_type'] !== ExpressionType::BRACKET_EXPRESSION) {
             return "";
@@ -97,6 +107,8 @@ class TableBracketExpressionBuilder implements Builder {
             $sql .= $this->buildLikeExpression($v);
             $sql .= $this->buildForeignKey($v);
             $sql .= $this->buildIndexKey($v);
+            $sql .= $this->buildUniqueIndex($v);
+            $sql .= $this->buildFulltextIndex($v);
                         
             if ($len == strlen($sql)) {
                 throw new UnableToCreateSQLException('CREATE TABLE create-def expression subtree', $k, $v, 'expr_type');

--- a/src/PHPSQLParser/builders/UniqueIndexBuilder.php
+++ b/src/PHPSQLParser/builders/UniqueIndexBuilder.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * IndexKeyBuilder.php
+ *
+ * Builds index key part of a CREATE TABLE statement.
+ *
+ * PHP version 5
+ *
+ * LICENSE:
+ * Copyright (c) 2010-2014 Justin Swanhart and André Rothe
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * @author    André Rothe <andre.rothe@phosco.info>
+ * @copyright 2010-2014 Justin Swanhart and André Rothe
+ * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
+ * @version   SVN: $Id$
+ * 
+ */
+
+namespace PHPSQLParser\builders;
+use PHPSQLParser\exceptions\UnableToCreateSQLException;
+use PHPSQLParser\utils\ExpressionType;
+
+/**
+ * This class implements the builder for the index key part of a CREATE TABLE statement. 
+ * You can overwrite all functions to achieve another handling.
+ *
+ * @author  André Rothe <andre.rothe@phosco.info>
+ * @license http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
+ *  
+ */
+class UniqueIndexBuilder implements Builder {
+
+    protected function buildReserved($parsed) {
+        $builder = new ReservedBuilder();
+        return $builder->build($parsed);
+    }
+
+    protected function buildConstant($parsed) {
+        $builder = new ConstantBuilder();
+        return $builder->build($parsed);
+    }
+    
+    protected function buildIndexType($parsed) {
+        $builder = new IndexTypeBuilder();
+        return $builder->build($parsed);
+    }
+    
+    protected function buildColumnList($parsed) {
+        $builder = new ColumnListBuilder();
+        return $builder->build($parsed);
+    }
+    
+    public function build(array $parsed) {
+        if ($parsed['expr_type'] !== ExpressionType::UNIQUE_IDX) {
+            return "";
+        }
+        $sql = "";
+        foreach ($parsed['sub_tree'] as $k => $v) {
+            $len = strlen($sql);
+            $sql .= $this->buildReserved($v);
+            $sql .= $this->buildColumnList($v);
+            $sql .= $this->buildConstant($v);
+            $sql .= $this->buildIndexType($v);
+
+            if ($len == strlen($sql)) {
+                throw new UnableToCreateSQLException('CREATE TABLE unique-index key subtree', $k, $v, 'expr_type');
+            }
+
+            $sql .= " ";
+        }
+        return substr($sql, 0, -1);
+    }
+}
+?>


### PR DESCRIPTION
This PR adds support for some missing builders when building `CREATE` statements

- Adds support for collation when building a column definition
```
CREATE TABLE `test_table` (
  `test_column` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
);
```
- Adds a builder to support for fulltext index in a CREATE statement
```
CREATE TABLE `test_table` (
  `test_column` varchar(255) DEFAULT NULL,
  FULLTEXT KEY `test_column` (`test_column`),
);
```
- Adds a builder to support unique index in a CREATE statement
```
CREATE TABLE `test_table` (
  `test_column` varchar(50) DEFAULT NULL,
  UNIQUE KEY `unique` (`test_column`),
);
```
- Adds support for a comment when building a column definition
```
CREATE TABLE `test_table` (
  `test_column` varchar(45) DEFAULT NULL COMMENT 'test comment,
)
```

The statements above would fail when running the following code
```
$parser = new \PHPSQLParser\PHPSQLParser();
$creator = new \PHPSQLParser\PHPSQLCreator();
$parsed = $parser->parse($sql);
$creator->create($parsed);
```