### PR TITLE
Remove CHARACTER keyword from column types

### DIFF
--- a/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php
+++ b/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php
@@ -187,7 +187,6 @@ class ColumnDefinitionProcessor extends AbstractProcessor {
                 continue 2;
 
             case 'CHAR':
-            case 'CHARACTER':   // Alias for CHAR
                 $expr[] = array('expr_type' => ExpressionType::DATA_TYPE, 'base_expr' => $trim, 'length' => false);
                 $currCategory = 'SINGLE_PARAM_PARENTHESIS';
                 $prevCategory = 'TEXT';

--- a/tests/cases/parser/issue320Test.php
+++ b/tests/cases/parser/issue320Test.php
@@ -39,9 +39,8 @@
  */
 namespace PHPSQLParser\Test\Parser;
 use PHPSQLParser\PHPSQLParser;
-use PHPSQLParser\PHPSQLCreator;
 
-class issue320Test extends \PHPUnit_Framework_TestCase
+class issue320Test extends \PHPUnit\Framework\TestCase
 {
     public function test_no_warning_is_issued_when_help_table_is_used()
     {
@@ -51,7 +50,7 @@ class issue320Test extends \PHPUnit_Framework_TestCase
         // there currently is an exception because `HELP` is a keyword
         // but this query seems valid at least in mysql and mssql
         // so ideally PHPSQLParser would be able to parse it
-        $this->setExpectedException(
+        $this->expectException(
             '\PHPSQLParser\exceptions\UnableToCalculatePositionException'
         );
 

--- a/tests/cases/parser/issue335Test.php
+++ b/tests/cases/parser/issue335Test.php
@@ -39,7 +39,7 @@ namespace PHPSQLParser\Test\Parser;
 
 use PHPSQLParser\PHPSQLParser;
 
-class issue335Test extends \PHPUnit_Framework_TestCase
+class issue335Test extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/tests/cases/parser/issue355Test.php
+++ b/tests/cases/parser/issue355Test.php
@@ -11,7 +11,6 @@ class issue355Test extends \PHPUnit\Framework\TestCase
         $sql = "
             CREATE TABLE `test_alias` (
               `a` INTEGER,
-              `b` CHARACTER(10),
               `c` VARCHARACTER(10),
               `d` INT2,
               `e` INT3,
@@ -24,9 +23,9 @@ class issue355Test extends \PHPUnit\Framework\TestCase
         ";
 		$parser = new PHPSQLParser();
         $parser->parse($sql, true);
-        // We expect to see 10 parsed columns
+        // We expect to see 9 parsed columns
         $this->assertEquals(
-            10,
+            9,
             count($parser->parsed['TABLE']['create-def']['sub_tree'])
         );
 


### PR DESCRIPTION
Fixes CREATE TABLE with 
```
`type` varchar (255) CHARACTER SET utf8 NOT NULL
```

as described in #365.

Also fixes unit tests with old TestCase class.