### PR TITLE
Fix confusion between CHARACTER data type and CHARACTER SET issue

### DIFF
--- a/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php
+++ b/src/PHPSQLParser/processors/ColumnDefinitionProcessor.php
@@ -82,6 +82,19 @@ class ColumnDefinitionProcessor extends AbstractProcessor {
         return $expr;
     }
 
+    protected function peekAtNextToken($tokens, $index)
+    {
+        $offset = $index + 1;
+        while (isset($tokens[$offset])) {
+            $token = trim($tokens[$offset]);
+            if ($token !== '') {
+                return strtoupper($token);
+            }
+            $offset++;
+        }
+        return '';
+    }
+
     public function process($tokens) {
 
         $trim = '';
@@ -187,7 +200,6 @@ class ColumnDefinitionProcessor extends AbstractProcessor {
                 continue 2;
 
             case 'CHAR':
-            case 'CHARACTER':   // Alias for CHAR
                 $expr[] = array('expr_type' => ExpressionType::DATA_TYPE, 'base_expr' => $trim, 'length' => false);
                 $currCategory = 'SINGLE_PARAM_PARENTHESIS';
                 $prevCategory = 'TEXT';
@@ -259,9 +271,23 @@ class ColumnDefinitionProcessor extends AbstractProcessor {
                 // spatial types
                 continue 2;
 
-            case 'CHARACTER':
+            case 'CHARSET':
                 $currCategory = 'CHARSET';
                 $options['sub_tree'][] = array('expr_type' => ExpressionType::RESERVED, 'base_expr' => $trim);
+                continue 2;
+
+            case 'CHARACTER':
+                // Alias of CHAR as well as pre-running for CHARACTER SET
+                // To determine which we peek at the next token to see if it's a SET or not.
+                if ($this->peekAtNextToken($tokens, $key) == 'SET') {
+                    $currCategory = 'CHARSET';
+                    $options['sub_tree'][] = array('expr_type' => ExpressionType::RESERVED, 'base_expr' => $trim);
+                // If it's not a SET we assume that it is a CHARACTER type definition
+                } else {
+                    $expr[] = array('expr_type' => ExpressionType::DATA_TYPE, 'base_expr' => $trim, 'length' => false);
+                    $currCategory = 'SINGLE_PARAM_PARENTHESIS';
+                    $prevCategory = 'TEXT';
+                }
                 continue 2;
 
             case 'SET':

--- a/tests/cases/parser/issue320Test.php
+++ b/tests/cases/parser/issue320Test.php
@@ -51,7 +51,7 @@ class issue320Test extends \PHPUnit\Framework\TestCase
         // there currently is an exception because `HELP` is a keyword
         // but this query seems valid at least in mysql and mssql
         // so ideally PHPSQLParser would be able to parse it
-        $this->setExpectedException(
+        $this->expectException(
             '\PHPSQLParser\exceptions\UnableToCalculatePositionException'
         );
 

--- a/tests/cases/parser/issue365Test.php
+++ b/tests/cases/parser/issue365Test.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * issue265.php
+ *
+ * Test case for PHPSQLCreator.
+ */
+
+namespace PHPSQLParser\Test\Creator;
+
+use PHPSQLParser\PHPSQLParser;
+use PHPSQLParser\PHPSQLCreator;
+
+class Issue365Test extends \PHPUnit\Framework\TestCase
+{
+    /*
+     * https://github.com/greenlion/PHP-SQL-Parser/issues/365
+     * Data type alias of character broken the CHARACTER SET parsing
+     */
+    public function testIssue365()
+    {
+        $sql = "CREATE TABLE IF NOT EXISTS example (`type` CHARACTER (255) CHARACTER SET utf8)";
+
+        $parser  = new PHPSQLParser($sql);
+        $parsed = $parser->parsed;
+        $create_def = $parsed['TABLE']['create-def'];
+        $sub_tree = $create_def['sub_tree'][0]['sub_tree'][1];
+
+        $this->assertEquals('utf8', $sub_tree['charset'], 'CHARACTER SET utf8');
+        $expected_type = [
+            'expr_type' => 'data-type',
+            'base_expr' => 'CHARACTER',
+            'length' => 255
+        ];
+        $this->assertEquals($expected_type, $sub_tree['sub_tree'][0], 'CHARACTER data type definition');
+    }
+
+    public function testIssue365BonusCharset()
+    {
+        $sql = "CREATE TABLE IF NOT EXISTS example (`type` CHARACTER (255) CHARSET utf8)";
+
+        $parser  = new PHPSQLParser($sql);
+        $parsed = $parser->parsed;
+        $create_def = $parsed['TABLE']['create-def'];
+        $sub_tree = $create_def['sub_tree'][0]['sub_tree'][1];
+
+        $this->assertEquals('utf8', $sub_tree['charset'], 'CHARACTER SET utf8');
+    }
+}


### PR DESCRIPTION
Confusion between `CHARACTER` type and `CHARACTER SET`

In an attempt to fix the data type aliases per https://github.com/greenlion/PHP-SQL-Parser/issues/355, I introduced a bug documented in https://github.com/greenlion/PHP-SQL-Parser/issues/365.

This change separates out the `CHARACTER` check to do a look ahead to see if the next keyword is `SET and splits the logic appropriately.

An alternative would be to look back at the constructed expression array (`$expr`) to see if a `ExpressionType::DATA_TYPE` has already been defined.

Additionally this also includes [a fix](https://github.com/greenlion/PHP-SQL-Parser/pull/376/commits/97edc852ba2e9cff3711629d6b8caceb168ea038#diff-c182eedc7b3e36d6ae1189e15b4fa2e6ab10f5e548f9a9431036277ea28af784R274) to support `CHARSET` which is a valid alias for `CHARACTER SET` per the [MySQL character sets documentation](https://dev.mysql.com/doc/refman/8.0/en/charset-syntax.html).

This is an alternative to the fix proposed by https://github.com/greenlion/PHP-SQL-Parser/pull/366