### PR TITLE
Added github actions to run phpunit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions:
+          - 5.4
+          - 5.5
+          - 5.6
+          - 7.2
+          - 7.3
+          - 7.4
+          - 8.2
+          - 8.3
+          - nightly
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: php-actions/composer@v6
+
+      - name: PHPUnit Tests
+        uses: php-actions/phpunit@master
+        env:
+          XDEBUG_MODE: coverage
+        with:
+          php_extensions: "xdebug"
+          coverage_html: "coverage/html/"
+          version: 9.5
+          bootstrap: tests/bootstrap.php
+          configuration: phpunit.xml
+
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: coverage/html

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,4 +8,9 @@
        <directory suffix="Test.php">tests</directory>
     </testsuite>
   </testsuites>
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
 </phpunit>


### PR DESCRIPTION
The ci.yml is configured to run the phpunit tests on any push to the repository. This will run the tests for a matrix of PHP versions to ensure all major versions supported are properly tests.

In addition, if the tests all pass, code coverage for the tests will be generated and uploaded as an artifact of the run so they can be downloaded and examined. To support this I needed to specify which directories to be included in the code coverage in the phpunit.xml file.

This merge request does not clean up any of the Travis CI configuration at this point in time.

To see how this will work you can see the output on my local project: https://github.com/xsist10/PHP-SQL-Parser/pull/1