### PR TITLE
Handle comments in FromBuilder

### DIFF
--- a/src/PHPSQLParser/builders/FromBuilder.php
+++ b/src/PHPSQLParser/builders/FromBuilder.php
@@ -40,7 +40,9 @@
  */
 
 namespace PHPSQLParser\builders;
+
 use PHPSQLParser\exceptions\UnableToCreateSQLException;
+use PHPSQLParser\utils\ExpressionType;
 
 /**
  * This class implements the builder for the [FROM] part. You can overwrite
@@ -93,11 +95,19 @@ class FromBuilder implements Builder {
             }
         }
         else {
+            $numberOfComments = 0;
+
             foreach ($parsed as $k => $v) {
+                $k -= $numberOfComments;
                 $len = strlen($sql);
                 $sql .= $this->buildTable($v, $k);
                 $sql .= $this->buildTableExpression($v, $k);
                 $sql .= $this->buildSubquery($v, $k);
+
+                if ($this->isComment($v)) {
+                    $sql .= $this->buildComment($v);
+                    $numberOfComments++;
+                }
 
                 if ($len == strlen($sql)) {
                     throw new UnableToCreateSQLException('FROM', $k, $v, 'expr_type');
@@ -106,5 +116,15 @@ class FromBuilder implements Builder {
         }
         return "FROM " . $sql;
     }
+
+    protected function isComment($parsed) {
+        return $parsed['expr_type'] === ExpressionType::COMMENT;
+    }
+
+    protected function buildComment($parsed) {
+        if (!$this->isComment($parsed)) {
+            return '';
+        }
+        return $parsed['value'] . ' ';
+    }
 }
-?>

--- a/tests/cases/creator/FromBuilderTest.php
+++ b/tests/cases/creator/FromBuilderTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * FromBuilder.php
+ *
+ * Builds the FROM statement
+ *
+ * PHP version 5
+ *
+ * LICENSE:
+ * Copyright (c) 2010-2014 Justin Swanhart and André Rothe
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author    André Rothe <andre.rothe@phosco.info>
+ * @copyright 2010-2014 Justin Swanhart and André Rothe
+ * @license   http://www.debian.org/misc/bsd.license  BSD License (3 Clause)
+ * @version   SVN: $Id$
+ *
+ */
+
+namespace PHPSQLParser\Test\Creator;
+
+use PHPSQLParser\PHPSQLParser;
+use PHPSQLParser\PHPSQLCreator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This class implements the builder for the [FROM] part. You can overwrite
+ * all functions to achieve another handling.
+ *
+ * @author Christian Stoller <christian.stoller@mail.de>
+ */
+class FromBuilderTest extends TestCase
+{
+    public function testComment()
+    {
+        $sql = "SELECT * FROM car /* test comment */ WHERE color = 'black'";
+        $parser = new PHPSQLParser($sql);
+        $creator = new PHPSQLCreator($parser->parsed);
+        $created = $creator->created;
+
+        // Comment and table name are interchanged, but this can be tolerated.
+        // Otherwise the parsing would be more complex.
+        $expected = "SELECT * FROM /* test comment */ car WHERE color = 'black'";
+
+        $this->assertSame($expected, $created, 'a comment in the from clause');
+    }
+}


### PR DESCRIPTION
The following SQL query could be parsed:

```sql
SELECT * FROM car /* test comment */ WHERE color = 'black'
```
but the creator was not able to generate a SQL query from the parsed tree. An `UnableToCreateSQLException` with the message `unknown [expr_type] = comment in "FROM" [0]` was thrown in `src/PHPSQLParser/builders/FromBuilder.php` in line 103.