### PR TITLE
Fix incorrect type in phpdoc params

### DIFF
--- a/src/PHPSQLParser/PHPSQLParser.php
+++ b/src/PHPSQLParser/PHPSQLParser.php
@@ -64,7 +64,7 @@ class PHPSQLParser {
      * Constructor. It simply calls the parse() function.
      * Use the public variable $parsed to get the output.
      *
-     * @param String|bool  $sql           The SQL statement.
+     * @param string|bool  $sql           The SQL statement.
      * @param bool $calcPositions True, if the output should contain [position], false otherwise.
      * @param array $options
      */
@@ -84,7 +84,7 @@ class PHPSQLParser {
      * of the positions needs some time, if you don't need positions in
      * your application, set the parameter to false.
      *
-     * @param String  $sql           The SQL statement.
+     * @param string  $sql           The SQL statement.
      * @param boolean $calcPositions True, if the output should contain [position], false otherwise.
      *
      * @return array An associative array with all meta information about the SQL statement.
@@ -108,7 +108,7 @@ class PHPSQLParser {
     /**
      * Add a custom function to the parser.  no return value
      *
-     * @param String $token The name of the function to add
+     * @param string $token The name of the function to add
      *
      * @return null
      */
@@ -119,7 +119,7 @@ class PHPSQLParser {
     /**
      * Remove a custom function from the parser.  no return value
      *
-     * @param String $token The name of the function to remove
+     * @param string $token The name of the function to remove
      *
      * @return null
      */


### PR DESCRIPTION
**Problem**: devsense PHP (vscode) reports "Use of unknown class: 'PHPSQLParser\String'" when calling `parse()`

**Solution**: Change params to `string`