### PR TITLE
Fix matrix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php-versions:
           - 5.4
@@ -14,10 +15,12 @@ jobs:
           - 7.2
           - 7.3
           - 7.4
+          - 8.0
+          - 8.1
           - 8.2
           - 8.3
           - 8.4
-          - nightly
+
 
     steps:
       - uses: actions/checkout@v3
@@ -25,15 +28,16 @@ jobs:
       - uses: php-actions/composer@v6
 
       - name: PHPUnit Tests
-        uses: php-actions/phpunit@master
+        uses: php-actions/phpunit@v4
         env:
           XDEBUG_MODE: coverage
         with:
-          php_extensions: "xdebug"
+          php_extensions: xdebug
           coverage_html: "coverage/html/"
           version: 9.5
           bootstrap: tests/bootstrap.php
           configuration: phpunit.xml
+          php_version: ${{ matrix.php-versions }}
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - 7.4
           - 8.2
           - 8.3
+          - 8.4
           - nightly
 
     steps:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
   backupStaticAttributes="false"
+  failOnDeprecation="true"
+  displayDetailsOnTestsThatTriggerDeprecations="true"
+  displayDetailsOnPhpunitDeprecations="true"
   verbose="true"
   bootstrap="tests/bootstrap.php">
   <testsuites>


### PR DESCRIPTION
When attempting to support PHP 8.4, we discovered that the matrix build is not functioning properly. 
I have added an option to PHPUnit to detect deprecated warnings based on the PHP version, and we are failing the CI with a warning. As a result, the CI is currently failing for PHP 8.4.
This pull request does not include fixes for PHP 8.4.
The fix for this issue will be addressed in a separate pull request.

During this process, we also found that the version of PHPUnit specified in composer.json only works with PHP 7.3 and later. Since PHP 7.x has already reached EOL, it should be removed from the supported versions, and PHP 8.x and later should be made mandatory.

This pull request does not include fixes for PHP 8.4.

https://github.com/dmnlk/PHP-SQL-Parser/actions/runs/12015495627